### PR TITLE
fix(jx): make running work properly

### DIFF
--- a/apps/cacvote-jx-terminal/backend/src/config.rs
+++ b/apps/cacvote-jx-terminal/backend/src/config.rs
@@ -13,7 +13,7 @@ pub(crate) const SYNC_INTERVAL: Duration = Duration::from_secs(5);
 #[command(author, version, about)]
 pub(crate) struct Config {
     /// URL of the CACVote server, e.g. `https://cacvote.example.com/`.
-    #[arg(long, env = "CACVote_URL")]
+    #[arg(long, env = "CACVOTE_URL")]
     pub(crate) cacvote_url: reqwest::Url,
 
     /// URL of the PostgreSQL database, e.g. `postgres://user:pass@host:port/dbname`.

--- a/apps/cacvote-jx-terminal/frontend/package.json
+++ b/apps/cacvote-jx-terminal/frontend/package.json
@@ -10,7 +10,7 @@
     "lint": "cargo fmt -- --check && cargo clippy -- -D warnings",
     "start": "concurrently 'npm:start:*' 'npm:build:css:watch'",
     "start:frontend": "dx serve --port 5000",
-    "start:backend": "pnpm --dir ../backend start",
+    "start:backend": "cd ../backend && cargo watch -x run",
     "build:css:watch": "tailwindcss -i input.css -o ./public/styles.css --watch",
     "test": "cargo test"
   },

--- a/apps/cacvote-mark/backend/.env
+++ b/apps/cacvote-mark/backend/.env
@@ -1,4 +1,4 @@
-CACVote_URL=http://localhost:8000/
+CACVOTE_URL=http://localhost:8000/
 VX_MACHINE_ID=cacvote-mark-dev
 
 # configures the printer to use for printing mailing labels

--- a/apps/cacvote-scan/backend/.env
+++ b/apps/cacvote-scan/backend/.env
@@ -1,4 +1,4 @@
 DATABASE_URL=postgres:cacvote_scan
 PORT=4001
-CACVote_URL=http://localhost:8000/
+CACVOTE_URL=http://localhost:8000/
 VX_MACHINE_ID=cacvote-scan-dev

--- a/apps/cacvote-scan/backend/src/config.rs
+++ b/apps/cacvote-scan/backend/src/config.rs
@@ -13,7 +13,7 @@ pub(crate) const SYNC_INTERVAL: Duration = Duration::from_secs(5);
 #[command(author, version, about)]
 pub(crate) struct Config {
     /// URL of the CACVote server, e.g. `https://cacvote.example.com/`.
-    #[arg(long, env = "CACVote_URL")]
+    #[arg(long, env = "CACVOTE_URL")]
     pub(crate) cacvote_url: reqwest::Url,
 
     /// URL of the PostgreSQL database, e.g. `postgres://user:pass@host:port/dbname`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,12 +124,6 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
-  apps/cacvote-jx-terminal/backend:
-    devDependencies:
-      is-ci-cli:
-        specifier: 2.2.0
-        version: 2.2.0
-
   apps/cacvote-jx-terminal/frontend:
     dependencies:
       tailwindcss:
@@ -447,12 +441,6 @@ importers:
       http-proxy-middleware:
         specifier: 1.0.6
         version: 1.0.6
-
-  apps/cacvote-scan/backend:
-    devDependencies:
-      is-ci-cli:
-        specifier: 2.2.0
-        version: 2.2.0
 
   apps/cacvote-scan/frontend:
     dependencies:


### PR DESCRIPTION
The rename from RAVE to CACVote messed up the environment variable name. Also, I removed the `package.json` for `jx/backend` since it's not a node package, but the frontend was depending its `package.json` scripts.
