### PR TITLE
fix(auth-rs): correctly send "get response" commands

### DIFF
--- a/libs/auth-rs/src/card_command.rs
+++ b/libs/auth-rs/src/card_command.rs
@@ -42,44 +42,49 @@ impl CardCommand {
     }
 
     #[must_use]
-    pub fn to_command_apdu(&self) -> CommandApdu {
-        let command_apdus = self.to_command_apdus();
-        assert_eq!(command_apdus.len(), 1);
-        command_apdus[0].clone()
+    pub fn new(ins: u8, p1: u8, p2: u8, data: Vec<u8>) -> Self {
+        Self {
+            secure_channel: false,
+            ins,
+            p1,
+            p2,
+            data,
+        }
     }
 
     /// The SELECT command is a standard command for selecting an applet.
     #[must_use]
     pub fn select(data: impl Into<Vec<u8>>) -> Self {
-        Self {
-            secure_channel: false,
-            ins: 0xa4,
-            p1: 0x04,
-            p2: 0x00,
-            data: data.into(),
-        }
-    }
-
-    /// The GET RESPONSE command is a standard command for retrieving additional APDU response data.
-    #[must_use]
-    pub fn get_response(length: u8) -> Self {
-        Self {
-            secure_channel: false,
-            ins: 0xc0,
-            p1: 0x00,
-            p2: 0x00,
-            data: vec![length],
-        }
+        Self::new(0xa4, 0x04, 0x00, data.into())
     }
 
     /// The GET DATA command is a standard command for retrieving data from the card.
     pub fn get_data(object_id: impl Into<Vec<u8>>) -> Result<Self, tlv::ConstructError> {
-        Ok(Self {
-            secure_channel: false,
-            ins: 0xcb,
-            p1: 0x3f,
-            p2: 0xff,
-            data: Tlv::new(0x5c, object_id.into()).try_into()?,
-        })
+        Ok(Self::new(
+            0xcb,
+            0x3f,
+            0xff,
+            Tlv::new(0x5c, object_id.into()).try_into()?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::card_reader::OPEN_FIPS_201_AID;
+
+    use super::*;
+
+    #[test]
+    fn test_select() {
+        let command = CardCommand::select(OPEN_FIPS_201_AID);
+        let apdus = command.to_command_apdus();
+        assert_eq!(
+            apdus,
+            vec![
+                CommandApdu::new(Cla::Standard, 0xa4, 0x04, 0x00, OPEN_FIPS_201_AID.to_vec())
+                    .unwrap(),
+            ]
+        );
     }
 }

--- a/libs/auth-rs/src/command_apdu.rs
+++ b/libs/auth-rs/src/command_apdu.rs
@@ -14,7 +14,7 @@ pub const MAX_RESPONSE_APDU_DATA_LENGTH: usize = MAX_APDU_LENGTH - 2;
 ///
 /// The CLA also indicates whether the APDU is being sent over a GlobalPlatform Secure Channel,
 /// typically used for initial card configuration.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Cla {
     Standard = 0x00,
     Chained = 0x10,
@@ -22,13 +22,24 @@ pub enum Cla {
     SecureChained = 0x1c,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CommandApdu {
+    /// Class byte
     cla: Cla,
+
+    /// Instruction byte
     ins: u8,
+
+    /// Parameter 1 byte
     p1: u8,
+
+    /// Parameter 2 byte
     p2: u8,
+
+    /// Length of the data field
     lc: u8,
+
+    /// Data field
     data: Vec<u8>,
 }
 
@@ -48,6 +59,20 @@ impl CommandApdu {
             lc: lc as u8,
             data,
         })
+    }
+
+    /// The GET RESPONSE command is a standard command for retrieving additional
+    /// APDU response data.
+    #[must_use]
+    pub fn get_response(length: u8) -> CommandApdu {
+        CommandApdu {
+            cla: Cla::Standard,
+            ins: 0xc0,
+            p1: 0x00,
+            p2: 0x00,
+            lc: length,
+            data: Vec::new(),
+        }
     }
 
     pub fn data(&self) -> &[u8] {

--- a/libs/auth-rs/src/hex_debug.rs
+++ b/libs/auth-rs/src/hex_debug.rs
@@ -1,0 +1,25 @@
+use std::fmt::Debug;
+
+use tracing::field::DebugValue;
+
+pub(crate) struct HexDebug<T: Debug>(pub T);
+
+impl<T: Debug> Debug for HexDebug<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:02x?}", self.0)
+    }
+}
+
+/// Wraps a `tracing` field value so that it is displayed as hex in debug output.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::hex_debug::hex_debug;
+///
+/// let data = vec![0x01, 0x02, 0x03];
+/// tracing::info!(data = hex_debug(&data));
+/// ```
+pub(crate) fn hex_debug<T: Debug>(t: T) -> DebugValue<HexDebug<T>> {
+    tracing::field::debug(HexDebug(t))
+}

--- a/libs/auth-rs/src/lib.rs
+++ b/libs/auth-rs/src/lib.rs
@@ -3,6 +3,7 @@ pub mod card_details;
 mod card_reader;
 mod certs;
 mod command_apdu;
+mod hex_debug;
 mod tlv;
 
 pub use card_command::CardCommand;


### PR DESCRIPTION
We were previously sending an extra byte for the length, but that's not how those commands work. This also adds some basic `tracing` logging that I used to figure out the bug.
