### PR TITLE
feat: verify signature of object payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,6 +3641,7 @@ dependencies = [
  "hmac-sha256",
  "lazy_static",
  "nanoid",
+ "openssl",
  "pretty_assertions",
  "proptest",
  "regex",

--- a/libs/auth-rs/src/lib.rs
+++ b/libs/auth-rs/src/lib.rs
@@ -1,7 +1,7 @@
 mod card_command;
 pub mod card_details;
 mod card_reader;
-mod certs;
+pub mod certs;
 mod command_apdu;
 mod hex_debug;
 mod tlv;

--- a/libs/types-rs/Cargo.toml
+++ b/libs/types-rs/Cargo.toml
@@ -13,6 +13,7 @@ hex = { workspace = true }
 hmac-sha256 = { workspace = true }
 lazy_static = { workspace = true }
 nanoid = { workspace = true }
+openssl = { workspace = true, optional = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -25,5 +26,6 @@ pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 
 [features]
-backend = ["sqlx"]
+backend = ["openssl", "sqlx"]
 sqlx = ["dep:sqlx"]
+openssl = ["dep:openssl"]

--- a/services/cacvote-server/Cargo.toml
+++ b/services/cacvote-server/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-types-rs = { workspace = true, features = ["sqlx"] }
+types-rs = { workspace = true, features = ["backend"] }
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/services/cacvote-server/src/app.rs
+++ b/services/cacvote-server/src/app.rs
@@ -62,18 +62,8 @@ async fn create_object(
     State(pool): State<PgPool>,
     object: Json<SignedObject>,
 ) -> Result<impl IntoResponse, Error> {
-    let payload = object.try_to_inner()?;
     let mut conn = pool.acquire().await?;
-
-    let object_id = db::create_object(
-        &mut conn,
-        &payload.object_type,
-        &object.payload,
-        &object.certificates,
-        &object.signature,
-    )
-    .await?;
-
+    let object_id = db::create_object(&mut conn, &object).await?;
     Ok((StatusCode::CREATED, object_id.to_string()))
 }
 

--- a/services/cacvote-server/src/client.rs
+++ b/services/cacvote-server/src/client.rs
@@ -219,18 +219,14 @@ mod tests {
                 assert_eq!(entry.object_id, object_id);
                 assert_eq!(entry.action, "create");
                 assert_eq!(entry.object_type, "test");
-                // TODO: check jurisdiction matches certificate
+                assert_eq!(entry.jurisdiction.as_str(), "st.dev-jurisdiction");
                 entry
             }
             _ => panic!("expected one journal entry, got: {entries:?}"),
         };
 
         // check the journal since the last entry
-        let journal_entry_id = entry.id;
-        assert_eq!(
-            client.get_journal_entries(Some(journal_entry_id)).await?,
-            vec![]
-        );
+        assert_eq!(client.get_journal_entries(Some(entry.id)).await?, vec![]);
 
         // get the object
         let signed_object = client.get_object_by_id(object_id).await?.unwrap();

--- a/services/cacvote-server/src/client.rs
+++ b/services/cacvote-server/src/client.rs
@@ -132,6 +132,12 @@ impl Client {
 mod tests {
     use std::net::TcpListener;
 
+    use openssl::{
+        hash::MessageDigest,
+        pkey::{PKey, Private, Public},
+        sign::{Signer, Verifier},
+        x509::X509,
+    };
     use serde_json::json;
     use types_rs::cacvote::Payload;
 
@@ -154,6 +160,34 @@ mod tests {
         Ok(Client::new(format!("http://{addr}").parse()?))
     }
 
+    fn load_keypair() -> color_eyre::Result<(Vec<u8>, PKey<Public>, PKey<Private>)> {
+        // uses the dev VxAdmin keypair because it has the Jurisdiction field
+        let private_key_pem =
+            include_bytes!("../../../libs/auth/certs/dev/vx-admin-private-key.pem");
+        let private_key = PKey::private_key_from_pem(private_key_pem)?;
+        let certificates =
+            include_bytes!("../../../libs/auth/certs/dev/vx-admin-cert-authority-cert.pem")
+                .to_vec();
+        let x509 = X509::from_pem(&certificates)?;
+        let public_key = x509.public_key()?;
+        Ok((certificates, public_key, private_key))
+    }
+
+    fn sign_and_verify(
+        payload: &[u8],
+        private_key: &PKey<Private>,
+        public_key: &PKey<Public>,
+    ) -> color_eyre::Result<Vec<u8>> {
+        let mut signer = Signer::new(MessageDigest::sha256(), private_key)?;
+        signer.update(&payload)?;
+        let signature = signer.sign_to_vec()?;
+
+        let mut verifier = Verifier::new(MessageDigest::sha256(), public_key)?;
+        verifier.update(&payload)?;
+        assert!(verifier.verify(&signature)?);
+        Ok(signature)
+    }
+
     #[sqlx::test(migrations = "db/migrations")]
     async fn test_client(pool: sqlx::PgPool) -> color_eyre::Result<()> {
         let client = setup(pool)?;
@@ -165,13 +199,16 @@ mod tests {
             data: serde_json::to_vec(&json!({ "hello": "world" }))?,
             object_type: "test".to_owned(),
         };
+        let payload = serde_json::to_vec(&payload)?;
+        let (certificates, public_key, private_key) = load_keypair()?;
+        let signature = sign_and_verify(&payload, &private_key, &public_key)?;
 
         // create the object
         let object_id = client
             .create_object(SignedObject {
-                payload: serde_json::to_vec(&payload)?,
-                certificates: vec![],
-                signature: vec![],
+                payload,
+                certificates: certificates.clone(),
+                signature: signature.clone(),
             })
             .await?;
 
@@ -201,9 +238,35 @@ mod tests {
         let round_trip_payload = signed_object.try_to_inner()?;
         let round_trip_payload_data: serde_json::Value =
             serde_json::from_slice(&round_trip_payload.data)?;
-        assert!(signed_object.certificates.is_empty());
-        assert!(signed_object.signature.is_empty());
+        assert_eq!(signed_object.certificates, certificates);
+        assert_eq!(signed_object.signature, signature);
         assert_eq!(round_trip_payload_data, json!({ "hello": "world" }));
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "db/migrations")]
+    async fn test_invalid_certificate(pool: sqlx::PgPool) -> color_eyre::Result<()> {
+        let client = setup(pool)?;
+
+        let payload = Payload {
+            data: serde_json::to_vec(&json!({ "hello": "world" }))?,
+            object_type: "test".to_owned(),
+        };
+        let payload = serde_json::to_vec(&payload)?;
+
+        client
+            .create_object(SignedObject {
+                payload,
+                // invalid certificates and signature
+                certificates: vec![],
+                signature: vec![],
+            })
+            .await
+            .unwrap_err();
+
+        // check that there are no journal entries
+        assert_eq!(client.get_journal_entries(None).await?, vec![]);
 
         Ok(())
     }


### PR DESCRIPTION
Uses OpenSSL to verify the signature for the payload based on the provided certificate. It doesn't yet verify the certificate itself.