### PR TITLE
build: reference `wasm-bindgen` 0.2.92

### DIFF
--- a/apps/cacvote-jx-terminal/frontend/Cargo.toml
+++ b/apps/cacvote-jx-terminal/frontend/Cargo.toml
@@ -24,6 +24,6 @@ serde_json = { workspace = true }
 time.workspace = true
 types-rs = { workspace = true }
 ui-rs = { workspace = true }
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2.92"
 wasm-logger = "0.2.0"
 web-sys = { version = "0.3.64", features = ["EventSource"] }

--- a/libs/ui-rs/Cargo.toml
+++ b/libs/ui-rs/Cargo.toml
@@ -14,6 +14,6 @@ getrandom = { version = "0.2", features = ["js"] }
 js-sys = { workspace = true }
 log = "0.4.19"
 time = { workspace = true }
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2.92"
 wasm-logger = "0.2.0"
 web-sys = { version = "0.3.64", features = ["EventSource"] }


### PR DESCRIPTION
That's the version that we're including anyway (notice `Cargo.lock` doesn't change). Any installation of `dioxus-cli` is going to include 0.2.92 and the versions have to match, so this just makes things a bit less confusing.
