### PR TITLE
fix(auth): properly parse the challenge response

### DIFF
--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -567,7 +567,16 @@ export class JavaCard implements Card {
         ),
       })
     );
-    const challengeSignature = generalAuthenticateResponse.subarray(4); // Trim metadata
+
+    const [, , generalAuthenticateDynamicAuthenticationBody] = parseTlv(
+      GENERAL_AUTHENTICATE.DYNAMIC_AUTHENTICATION_TEMPLATE_TAG,
+      generalAuthenticateResponse
+    );
+
+    const [, , challengeSignature] = parseTlv(
+      GENERAL_AUTHENTICATE.RESPONSE_TAG,
+      generalAuthenticateDynamicAuthenticationBody
+    );
 
     // Use the cert's public key to verify the generated signature
     const certPublicKey = await extractPublicKeyFromCert(cert);


### PR DESCRIPTION
## Overview

Rather than hardcoding a fixed number of bytes to trim we now properly parse the nested response TLV structures. While the old way didn't bite us in practice, if the signature returned was ever larger than 0x80 bytes the TLV would use two bytes to encode the length and the signature would be corrupted.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests, plus manual testing with a sysadmin card.
