### PR TITLE
fix(jx): improve reliability of smartcard detection and status stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "dotenvy",
+ "futures",
  "futures-core",
  "mockall",
  "openssl",
@@ -1173,6 +1174,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1271,7 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3322,6 +3339,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dioxus-router = "0.4.1"
 dioxus-web = { version = "0.4" }
 dotenvy = "0.15.7"
 env_logger = "0.10.0"
+futures = "0.3.28"
 futures-core = "0.3.28"
 hex = "0.4.3"
 hmac-sha256 = "1.1.7"
@@ -64,7 +65,7 @@ tokio = { version = "1.29.1", default-features = false, features = [
     "sync",
     "macros",
 ] }
-tokio-stream = "0.1.14"
+tokio-stream = { version = "0.1.14", features = ["sync"] }
 tower-http = { version = "0.4.3", features = ["fs"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"

--- a/apps/cacvote-jx-terminal/backend/Cargo.toml
+++ b/apps/cacvote-jx-terminal/backend/Cargo.toml
@@ -16,6 +16,7 @@ clap = { workspace = true }
 color-eyre = { workspace = true }
 dotenvy = { workspace = true }
 futures-core = { workspace = true }
+futures = { workspace = true }
 openssl = { workspace = true }
 pcsc = { workspace = true }
 regex = { workspace = true }

--- a/apps/cacvote-jx-terminal/backend/src/app.rs
+++ b/apps/cacvote-jx-terminal/backend/src/app.rs
@@ -7,7 +7,6 @@ use std::convert::Infallible;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
-use async_stream::try_stream;
 use auth_rs::card_details::CardDetailsWithAuthInfo;
 use axum::body::Bytes;
 use axum::response::sse::{Event, KeepAlive};
@@ -16,22 +15,27 @@ use axum::routing::post;
 use axum::Json;
 use axum::{extract::DefaultBodyLimit, routing::get, Router};
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
-use futures_core::Stream;
+use futures::stream::Stream;
 use serde_json::json;
 use sqlx::PgPool;
-use tokio::time::sleep;
+use tokio_stream::StreamExt;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tracing::Level;
-use types_rs::cacvote::{AuthStatus, Election, Payload, SessionData, SignedObject};
+use types_rs::cacvote::{Election, Payload, SessionData, SignedObject};
 use types_rs::election::ElectionDefinition;
 use uuid::Uuid;
 
 use crate::config::{Config, MAX_REQUEST_SIZE};
 use crate::{db, smartcard};
+use tokio::sync::broadcast;
 
-// type AppState = (Config, PgPool, smartcard::StatusGetter);
-type AppState = (Config, PgPool, smartcard::DynSmartcard);
+#[derive(Clone)]
+struct AppState {
+    pool: PgPool,
+    smartcard: smartcard::DynSmartcard,
+    broadcast_tx: broadcast::Sender<SessionData>,
+}
 
 /// Prepares the application with all the routes. Run the application with
 /// `app::run(…)` once you have it.
@@ -50,6 +54,44 @@ pub(crate) fn setup(pool: PgPool, config: Config, smartcard: smartcard::DynSmart
         }
     };
 
+    let (broadcast_tx, _) = broadcast::channel(1);
+
+    tokio::spawn({
+        let jurisdiction_code = config.jurisdiction_code.clone();
+        let pool = pool.clone();
+        let smartcard = smartcard.clone();
+        let broadcast_tx = broadcast_tx.clone();
+        async move {
+            loop {
+                let mut connection = pool.acquire().await.unwrap();
+
+                let session_data = match smartcard.get_card_details() {
+                    Some(CardDetailsWithAuthInfo { card_details, .. })
+                        if card_details.jurisdiction_code() == jurisdiction_code =>
+                    {
+                        let elections = db::get_elections(&mut connection).await.unwrap();
+                        SessionData::Authenticated {
+                            jurisdiction_code: jurisdiction_code.clone(),
+                            elections: elections
+                                .into_iter()
+                                .map(|e| e.election_definition)
+                                .collect(),
+                        }
+                    }
+                    Some(_) => SessionData::Unauthenticated {
+                        has_smartcard: true,
+                    },
+                    None => SessionData::Unauthenticated {
+                        has_smartcard: false,
+                    },
+                };
+
+                let _ = broadcast_tx.send(session_data);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    });
+
     router
         .route("/api/status", get(get_status))
         .route("/api/status-stream", get(get_status_stream))
@@ -57,7 +99,11 @@ pub(crate) fn setup(pool: PgPool, config: Config, smartcard: smartcard::DynSmart
         .route("/api/elections", post(create_election))
         .layer(DefaultBodyLimit::max(MAX_REQUEST_SIZE))
         .layer(TraceLayer::new_for_http())
-        .with_state((config, pool, smartcard))
+        .with_state(AppState {
+            pool,
+            smartcard,
+            broadcast_tx,
+        })
 }
 
 /// Runs an application built by `app::setup(…)`.
@@ -74,34 +120,33 @@ async fn get_status() -> impl IntoResponse {
     StatusCode::OK
 }
 
-async fn get_status_stream(
-    State((config, _, smartcard)): State<AppState>,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    Sse::new(try_stream! {
-        let mut last_card_details = None;
-
-        loop {
-            let new_card_details = smartcard.get_card_details();
-
-            if new_card_details != last_card_details {
-                last_card_details = new_card_details.clone();
-                yield Event::default().json_data(SessionData {
-                    auth_status: match new_card_details {
-                        Some(CardDetailsWithAuthInfo { card_details, .. }) if card_details.jurisdiction_code() == config.jurisdiction_code => AuthStatus::Authenticated,
-                        Some(_) => AuthStatus::UnauthenticatedInvalidCard,
-                        None => AuthStatus::UnauthenticatedNoCard,
-                    },
-                    jurisdiction_code: Some(config.jurisdiction_code.clone()),
-                }).unwrap();
-            }
-
-            sleep(Duration::from_millis(100)).await;
-        }
+fn distinct_until_changed<S: Stream>(stream: S) -> impl Stream<Item = S::Item>
+where
+    S::Item: Clone + PartialEq,
+{
+    let mut last = None;
+    stream.filter(move |item| {
+        let changed = last.as_ref() != Some(item);
+        last = Some(item.clone());
+        changed
     })
-    .keep_alive(KeepAlive::default())
 }
 
-async fn get_elections(State((_, pool, _)): State<AppState>) -> impl IntoResponse {
+async fn get_status_stream(
+    State(AppState { broadcast_tx, .. }): State<AppState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let broadcast_rx = broadcast_tx.subscribe();
+
+    let stream = distinct_until_changed(
+        tokio_stream::wrappers::BroadcastStream::new(broadcast_rx).filter_map(Result::ok),
+    )
+    .map(|data| Event::default().json_data(data).unwrap())
+    .map(Ok);
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+async fn get_elections(State(AppState { pool, .. }): State<AppState>) -> impl IntoResponse {
     let mut connection = match pool.acquire().await {
         Ok(connection) => connection,
         Err(e) => {
@@ -128,7 +173,9 @@ async fn get_elections(State((_, pool, _)): State<AppState>) -> impl IntoRespons
 }
 
 async fn create_election(
-    State((_, pool, smartcard)): State<AppState>,
+    State(AppState {
+        pool, smartcard, ..
+    }): State<AppState>,
     body: Bytes,
 ) -> impl IntoResponse {
     let jurisdiction_code = match smartcard.get_card_details() {

--- a/apps/cacvote-jx-terminal/backend/src/db.rs
+++ b/apps/cacvote-jx-terminal/backend/src/db.rs
@@ -48,6 +48,7 @@ pub(crate) async fn get_elections(
             signature
         FROM objects
         WHERE object_type = 'Election'
+        ORDER BY created_at DESC
         "#,
     )
     .fetch_all(connection)
@@ -58,7 +59,7 @@ pub(crate) async fn get_elections(
     for object in objects {
         let payload = match object.try_to_inner() {
             Ok(payload) => {
-                tracing::debug!("got object payload: {payload:?}");
+                tracing::trace!("got object payload: {payload:?}");
                 payload
             }
             Err(err) => {

--- a/apps/cacvote-jx-terminal/frontend/src/pages/elections_page.rs
+++ b/apps/cacvote-jx-terminal/frontend/src/pages/elections_page.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use dioxus_router::hooks::use_navigator;
-use serde::Deserialize;
-use types_rs::cacvote::{Election, SessionData};
+use types_rs::cacvote::SessionData;
 use ui_rs::FileButton;
 
 use crate::{
@@ -17,46 +16,10 @@ pub fn ElectionsPage(cx: Scope) -> Element {
     let nav = use_navigator(cx);
     let session_data = use_shared_state::<SessionData>(cx).unwrap();
     let session_data = &*session_data.read();
-
-    let elections = use_state(cx, Vec::new);
-
-    use_effect(cx, (), |()| {
-        to_owned![elections];
-        async move {
-            #[derive(Deserialize)]
-            struct GetElectionsResponse {
-                elections: Vec<Election>,
-            }
-
-            let url = get_url("/api/elections");
-            let client = reqwest::Client::new();
-            let res = client.get(url).send().await;
-
-            match res {
-                Ok(res) => {
-                    if res.status().is_success() {
-                        match res.json::<GetElectionsResponse>().await {
-                            Ok(response) => {
-                                elections.set(response.elections);
-                            }
-                            Err(err) => {
-                                log::error!("failed to parse elections: {err}");
-                            }
-                        }
-                        log::info!("elections: {elections:?}");
-                    } else {
-                        log::error!(
-                            "failed to get elections: {:?}",
-                            res.text().await.unwrap_or("unknown error".to_owned())
-                        );
-                    }
-                }
-                Err(err) => {
-                    log::error!("failed to get elections: {err}");
-                }
-            }
-        }
-    });
+    let elections = match session_data {
+        SessionData::Authenticated { elections, .. } => Some(elections),
+        _ => None,
+    };
 
     let is_uploading = use_state(cx, || false);
     let upload_election = {
@@ -82,7 +45,7 @@ pub fn ElectionsPage(cx: Scope) -> Element {
     use_effect(cx, (session_data,), |(session_data,)| {
         to_owned![nav, session_data];
         async move {
-            if session_data.jurisdiction_code.is_none() {
+            if matches!(session_data, SessionData::Unauthenticated { .. }) {
                 nav.push(Route::MachineLockedPage);
             }
         }
@@ -91,69 +54,69 @@ pub fn ElectionsPage(cx: Scope) -> Element {
     render! (
         div {
             h1 { class: "text-2xl font-bold mb-4", "Elections" }
-            if elections.is_empty() {
-                rsx!(div { "No elections found." })
-            } else {
-                rsx!(
-                    table {
-                        class: "table-auto w-full",
-                        thead {
-                            tr {
-                                th { class: "px-4 py-2 text-left", "Title" }
+            match elections.map(Vec::as_slice) {
+                None | Some([]) => {
+                    rsx!(div { "No elections found." })
+                }
+                Some(election_definitions) => {
+                    rsx!(
+                        table {
+                            class: "table-auto w-full",
+                            thead {
+                                tr {
+                                    th { class: "px-4 py-2 text-left", "Title" }
+                                }
+                            }
+                            for election_definition in election_definitions.iter() {
+                                tr {
+                                    td { class: "border px-4 py-2 text-sm", "{election_definition.election.title}" }
+                                }
                             }
                         }
-                        for election in elections.iter() {
-                            tr {
-                                td { class: "border px-4 py-2 text-sm", "{election.election_definition.election.title}" }
-                            }
-                        }
-                    }
-                )
-            }
+                    )
+                }
+            },
             FileButton {
-                    "Import Election",
-                    class: "mt-4",
-                    onfile: move |file_engine: Arc<dyn FileEngine>| {
-                        cx.spawn({
-                            to_owned![upload_election, file_engine];
-                            async move {
-                                if let Some(election_data) = read_file_as_bytes(file_engine).await {
-                                    match upload_election(election_data).await {
-                                        Some(Ok(response)) => {
-                                            if !response.status().is_success() {
-                                                web_sys::window()
-                                                    .unwrap()
-                                                    .alert_with_message(
-                                                        &format!(
-                                                            "Failed to upload election: {:?}",
-                                                            response
-                                                                .text()
-                                                                .await
-                                                                .unwrap_or("unknown error".to_owned())
-                                                        ),
-                                                    )
-                                                    .unwrap();
-                                                return;
-                                            }
-
-                                            log::info!("Election uploaded successfully");
-                                        }
-                                        Some(Err(err)) => {
-                                            log::error!("Failed to upload election: {err}");
-
+                class: "mt-4",
+                onfile: move |file_engine: Arc<dyn FileEngine>| {
+                    cx.spawn({
+                        to_owned![upload_election, file_engine];
+                        async move {
+                            if let Some(election_data) = read_file_as_bytes(file_engine).await {
+                                match upload_election(election_data).await {
+                                    Some(Ok(response)) => {
+                                        if !response.status().is_success() {
                                             web_sys::window()
                                                 .unwrap()
-                                                .alert_with_message(&format!("Failed to upload election: {err}"))
+                                                .alert_with_message(
+                                                    &format!(
+                                                        "Failed to upload election: {:?}",
+                                                        response.text().await.unwrap_or("unknown error".to_owned()),
+                                                    ),
+                                                )
                                                 .unwrap();
+                                            return;
                                         }
-                                        None => {
-                                            log::error!("Invalid election data");
-                                        }
+                                        log::info!("Election uploaded successfully");
                                     }
-                                };
+                                    Some(Err(err)) => {
+                                        log::error!("Failed to upload election: {err}");
+                                        web_sys::window()
+                                            .unwrap()
+                                            .alert_with_message(
+                                                &format!("Failed to upload election: {err}"),
+                                            )
+                                            .unwrap();
+                                    }
+                                    None => {
+                                        log::error!("Invalid election data");
+                                    }
+                                }
                             }
-                        });
-                    },
+                        }
+                    });
+                },
+                "Import Election"
             }
         }
     )

--- a/libs/types-rs/src/cacvote/mod.rs
+++ b/libs/types-rs/src/cacvote/mod.rs
@@ -387,17 +387,22 @@ impl JurisdictionScoped for Election {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-pub enum AuthStatus {
-    #[default]
-    UnauthenticatedNoCard,
-    UnauthenticatedInvalidCard,
-    Authenticated,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionData {
+    Authenticated {
+        jurisdiction_code: JurisdictionCode,
+        elections: Vec<ElectionDefinition>,
+    },
+    Unauthenticated {
+        has_smartcard: bool,
+    },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionData {
-    pub auth_status: AuthStatus,
-    pub jurisdiction_code: Option<JurisdictionCode>,
+impl Default for SessionData {
+    fn default() -> Self {
+        Self::Unauthenticated {
+            has_smartcard: false,
+        }
+    }
 }


### PR DESCRIPTION

Replaces `try_stream!` with a broadcast stream. This means that no matter how many requests we get for the status stream endpoint we only collect the data for it in one place. Previously, the loop inside the `try_stream!` would run even after the connection was closed, resulting in excess resource usage.
