### PR TITLE
fix(mprocs): specify the binary for JX backend

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,11 +1,11 @@
 procs:
   cacvote-server:
     cwd: 'services/cacvote-server'
-    shell: 'cargo watch -x run'
+    shell: 'cargo watch -- cargo run'
 
   cacvote-jx-backend:
     cwd: 'apps/cacvote-jx-terminal/backend'
-    shell: 'cargo watch -x run'
+    shell: 'cargo watch -- cargo run --bin cacvote-jx-terminal-backend'
   cacvote-jx-frontend:
     cwd: 'apps/cacvote-jx-terminal/frontend'
     shell: 'dx serve --port 5000'


### PR DESCRIPTION
Since I added another binary we can't just do `cargo run` anymore, we have to specify which binary we want to run. This required changing the style for the `cargo watch` invocation, so I also changed it for `cacvote-server` just to be consistent.
