### PR TITLE
feat(jx): add election screens (info, tally)

### DIFF
--- a/apps/cacvote-jx-terminal/backend/src/db.rs
+++ b/apps/cacvote-jx-terminal/backend/src/db.rs
@@ -521,6 +521,7 @@ pub(crate) async fn get_cast_ballots(
                         cast_ballot,
                         registration_request,
                         registration,
+                        registration_object.id,
                         verification_status,
                         created_at,
                     ));

--- a/apps/cacvote-jx-terminal/frontend/src/app_root.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/app_root.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
+import * as api from './api';
+import { ElectionScreen } from './screens/election_screen';
 import { ElectionsScreen } from './screens/elections_screen';
 import { InsertCardScreen } from './screens/insert_card_screen';
-import * as api from './api';
 import { VotersScreen } from './screens/voters_screen';
+import { TallyScreen } from './screens/tally_screen';
 
 export function AppRoot(): JSX.Element {
   const history = useHistory();
@@ -27,6 +29,12 @@ export function AppRoot(): JSX.Element {
       </Route>
       <Route exact path="/elections">
         <ElectionsScreen />
+      </Route>
+      <Route exact path="/elections/:electionId">
+        <ElectionScreen />
+      </Route>
+      <Route exact path="/elections/:electionId/tally">
+        <TallyScreen />
       </Route>
       <Route exact path="/voters">
         <VotersScreen />

--- a/apps/cacvote-jx-terminal/frontend/src/cacvote-server/session_data.ts
+++ b/apps/cacvote-jx-terminal/frontend/src/cacvote-server/session_data.ts
@@ -200,6 +200,7 @@ export interface CastBallotPresenter {
   castBallot: CastBallot;
   registrationRequest: RegistrationRequest;
   registration: Registration;
+  registrationId: Uuid;
   verificationStatus: VerificationStatus;
 
   /**
@@ -213,6 +214,7 @@ export const CastBallotPresenterSchema: z.ZodSchema<CastBallotPresenter> =
     castBallot: CastBallotSchema,
     registrationRequest: RegistrationRequestSchema,
     registration: RegistrationSchema,
+    registrationId: UuidSchema,
     verificationStatus: VerificationStatusSchema,
     createdAt: z.string(),
   });

--- a/apps/cacvote-jx-terminal/frontend/src/components/date_time_cell.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/date_time_cell.tsx
@@ -1,0 +1,17 @@
+import { P, TD } from '@votingworks/ui';
+import { DateTime } from 'luxon';
+
+export interface DateTimeCellProps {
+  dateTime: DateTime | string;
+}
+
+export function DateTimeCell({ dateTime }: DateTimeCellProps): JSX.Element {
+  const dt =
+    typeof dateTime === 'string' ? DateTime.fromISO(dateTime) : dateTime;
+
+  return (
+    <TD>
+      <P>{dt.toLocaleString(DateTime.DATETIME_SHORT)}</P>
+    </TD>
+  );
+}

--- a/apps/cacvote-jx-terminal/frontend/src/components/election_card.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/election_card.tsx
@@ -1,0 +1,35 @@
+import { Election } from '@votingworks/types';
+import { Card, H2, P, Seal } from '@votingworks/ui';
+import { format } from '@votingworks/utils';
+import styled from 'styled-components';
+
+const Wrapper = styled(Card).attrs({ color: 'neutral' })`
+  margin: 1rem 0;
+
+  > div {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem;
+  }
+`;
+
+export interface ElectionCardProps {
+  election: Election;
+}
+
+export function ElectionCard({ election }: ElectionCardProps): JSX.Element {
+  return (
+    <Wrapper>
+      <Seal seal={election.seal} maxWidth="7rem" />
+      <div>
+        <H2 as="h3">{election.title}</H2>
+        <P>
+          {election.county.name}, {election.state}
+          <br />
+          {format.localeDate(new Date(election.date))}
+        </P>
+      </div>
+    </Wrapper>
+  );
+}

--- a/apps/cacvote-jx-terminal/frontend/src/components/registration_configuration_cell.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/registration_configuration_cell.tsx
@@ -1,0 +1,25 @@
+import { BallotStyleId, PrecinctId } from '@votingworks/types';
+import { P, TD } from '@votingworks/ui';
+
+export interface RegistrationsConfigurationCellProps {
+  electionTitle: string;
+  ballotStyleId: BallotStyleId;
+  precinctId: PrecinctId;
+}
+
+export function RegistrationConfigurationCell({
+  electionTitle,
+  ballotStyleId,
+  precinctId,
+}: RegistrationsConfigurationCellProps): JSX.Element {
+  return (
+    <TD>
+      <P>{electionTitle}</P>
+      <P>
+        <em>Ballot Style:</em> {ballotStyleId}
+        <br />
+        <em>Precinct:</em> {precinctId}
+      </P>
+    </TD>
+  );
+}

--- a/apps/cacvote-jx-terminal/frontend/src/components/voter_info_cell.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/voter_info_cell.tsx
@@ -1,0 +1,20 @@
+import { P, TD } from '@votingworks/ui';
+
+export interface VoterInfoCellProps {
+  displayName: string;
+  commonAccessCardId: string;
+}
+
+export function VoterInfoCell({
+  displayName,
+  commonAccessCardId,
+}: VoterInfoCellProps): JSX.Element {
+  return (
+    <TD>
+      <P>{displayName}</P>
+      <P>
+        <em>CAC:</em> {commonAccessCardId}
+      </P>
+    </TD>
+  );
+}

--- a/apps/cacvote-jx-terminal/frontend/src/screens/election_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/election_screen.tsx
@@ -1,0 +1,136 @@
+import { assertDefined } from '@votingworks/basics';
+import { Button, H2, P, TD, TH, Table } from '@votingworks/ui';
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import * as api from '../api';
+import {
+  CastBallotPresenter,
+  RegistrationPresenter,
+} from '../cacvote-server/session_data';
+import { Uuid } from '../cacvote-server/types';
+import { DateTimeCell } from '../components/date_time_cell';
+import { ElectionCard } from '../components/election_card';
+import { RegistrationConfigurationCell } from '../components/registration_configuration_cell';
+import { VoterInfoCell } from '../components/voter_info_cell';
+import { NavigationScreen } from './navigation_screen';
+
+interface RegistrationsTableProps {
+  registrations: readonly RegistrationPresenter[];
+  castBallots: readonly CastBallotPresenter[];
+}
+
+function VotersAndBallotsTable({
+  registrations,
+  castBallots,
+}: RegistrationsTableProps): JSX.Element {
+  const castBallotsByRegistrationId = new Map<Uuid, CastBallotPresenter>();
+
+  for (const castBallot of castBallots) {
+    castBallotsByRegistrationId.set(castBallot.registrationId, castBallot);
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <TH>Voter</TH>
+          <TH>Election Configuration</TH>
+          <TH>Registered</TH>
+          <TH>Ballot Cast</TH>
+        </tr>
+      </thead>
+      <tbody>
+        {registrations.map((r) => {
+          const castBallot = castBallotsByRegistrationId.get(r.id);
+          return (
+            <tr key={r.id}>
+              <VoterInfoCell
+                displayName={r.displayName}
+                commonAccessCardId={r.registration.commonAccessCardId}
+              />
+              <RegistrationConfigurationCell
+                electionTitle={r.electionTitle}
+                ballotStyleId={r.registration.ballotStyleId}
+                precinctId={r.registration.precinctId}
+              />
+              <DateTimeCell dateTime={r.createdAt} />
+              {castBallot ? (
+                <DateTimeCell dateTime={castBallot.createdAt} />
+              ) : (
+                <TD>
+                  <P>No ballot cast</P>
+                </TD>
+              )}
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}
+
+export interface ElectionScreenParams {
+  electionId: string;
+}
+
+export function ElectionScreen(): JSX.Element | null {
+  const sessionDataQuery = api.sessionData.useQuery();
+  const sessionData = sessionDataQuery.data;
+  const { electionId } = useParams<ElectionScreenParams>();
+  const history = useHistory();
+
+  if (sessionData?.type !== 'authenticated' || !electionId) {
+    return null;
+  }
+
+  const electionPresenter = assertDefined(
+    sessionData.elections.find((e) => e.id === electionId)
+  );
+
+  const registrations = sessionData.registrations.filter(
+    (r) => r.registration.electionObjectId === electionId
+  );
+
+  const castBallots = sessionData.castBallots.filter(
+    (b) => b.registration.electionObjectId === electionId
+  );
+
+  function onPressTallyButton() {
+    history.push(`/elections/${electionId}/tally`);
+  }
+
+  return (
+    <NavigationScreen
+      title={electionPresenter.election.electionDefinition.election.title}
+      parentRoutes={[{ title: 'Elections', path: '/elections' }]}
+    >
+      <H2>Election Information</H2>
+      <ElectionCard
+        election={electionPresenter.election.electionDefinition.election}
+      />
+
+      <H2>Voters &amp; Ballots</H2>
+      {registrations.length > 0 ? (
+        <React.Fragment>
+          <VotersAndBallotsTable
+            registrations={registrations}
+            castBallots={castBallots}
+          />
+          <br />
+          <Button
+            variant={
+              registrations.length === castBallots.length
+                ? 'primary'
+                : 'neutral'
+            }
+            onPress={onPressTallyButton}
+          >
+            Go to Ballot Tally
+          </Button>
+        </React.Fragment>
+      ) : (
+        <P>No registered voters or cast ballots yet.</P>
+      )}
+    </NavigationScreen>
+  );
+}

--- a/apps/cacvote-jx-terminal/frontend/src/screens/elections_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/elections_screen.tsx
@@ -1,21 +1,10 @@
-import { Button, Card, H2, P, Seal } from '@votingworks/ui';
-import { format } from '@votingworks/utils';
+import { Button } from '@votingworks/ui';
 import { useState } from 'react';
-import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import * as api from '../api';
-import { NavigationScreen } from './navigation_screen';
 import { CreateElectionModal } from '../components/create_election_modal';
-
-const ElectionCard = styled(Card).attrs({ color: 'neutral' })`
-  margin: 1rem 0;
-
-  > div {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    padding: 1rem;
-  }
-`;
+import { ElectionCard } from '../components/election_card';
+import { NavigationScreen } from './navigation_screen';
 
 export function ElectionsScreen(): JSX.Element | null {
   const sessionDataQuery = api.sessionData.useQuery();
@@ -38,19 +27,9 @@ export function ElectionsScreen(): JSX.Element | null {
             electionDefinition: { election },
           },
         }) => (
-          // <Link to={`/elections/${id}`} key={id}>
-          <ElectionCard key={id}>
-            <Seal seal={election.seal} maxWidth="7rem" />
-            <div>
-              <H2 as="h3">{election.title}</H2>
-              <P>
-                {election.county.name}, {election.state}
-                <br />
-                {format.localeDate(new Date(election.date))}
-              </P>
-            </div>
-          </ElectionCard>
-          // </Link>
+          <Link to={`/elections/${id}`} key={id}>
+            <ElectionCard election={election} />
+          </Link>
         )
       )}
       <Button icon="Add" onPress={() => setIsShowingAddElectionModal(true)}>
@@ -58,6 +37,7 @@ export function ElectionsScreen(): JSX.Element | null {
       </Button>
       {isShowingAddElectionModal && (
         <CreateElectionModal
+          isCreating={createElectionMutation.isLoading}
           onCreate={({ mailingAddress, electionDefinition }) =>
             createElectionMutation.mutate(
               {

--- a/apps/cacvote-jx-terminal/frontend/src/screens/navigation_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/navigation_screen.tsx
@@ -29,12 +29,14 @@ interface Props {
   children: React.ReactNode;
   title?: string;
   parentRoutes?: Route[];
+  headerActions?: React.ReactNode;
 }
 
 export function NavigationScreen({
   children,
   title,
   parentRoutes,
+  headerActions,
 }: Props): JSX.Element | null {
   const sessionDataQuery = api.sessionData.useQuery();
   const sessionData = sessionDataQuery.data;
@@ -66,6 +68,7 @@ export function NavigationScreen({
               </React.Fragment>
             )}
           </div>
+          {headerActions}
         </Header>
         <MainContent>{children}</MainContent>
       </Main>

--- a/apps/cacvote-jx-terminal/frontend/src/screens/tally_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/tally_screen.tsx
@@ -1,0 +1,56 @@
+import { assertDefined } from '@votingworks/basics';
+import { H2, P } from '@votingworks/ui';
+import { useParams } from 'react-router-dom';
+import * as api from '../api';
+import { NavigationScreen } from './navigation_screen';
+
+export interface TallyScreenParams {
+  electionId: string;
+}
+
+export function TallyScreen(): JSX.Element | null {
+  const sessionDataQuery = api.sessionData.useQuery();
+  const sessionData = sessionDataQuery.data;
+  const { electionId } = useParams<TallyScreenParams>();
+
+  if (sessionData?.type !== 'authenticated' || !electionId) {
+    return null;
+  }
+
+  const electionPresenter = assertDefined(
+    sessionData.elections.find((e) => e.id === electionId)
+  );
+
+  return (
+    <NavigationScreen
+      title="Tally Election"
+      parentRoutes={[
+        { title: 'Elections', path: '/elections' },
+        {
+          title: electionPresenter.election.electionDefinition.election.title,
+          path: `/elections/${electionId}`,
+        },
+      ]}
+    >
+      <H2>Encrypted Election Tally</H2>
+      <P>
+        TODO: Once all the ballots have been received, this section should allow
+        a user to generate an encrypted tally of the election. This will
+        disallow syncing any further ballots from the server. The encrypted
+        tally should be downloadable from this section.
+      </P>
+      <P>
+        TODO: If the encrypted tally has already been generated, just show it
+        here (i.e. for download).
+      </P>
+
+      <H2>Decrypted Election Tally</H2>
+      <P>
+        TODO: Once the encrypted election tally exists, this section should
+        allow a user to decrypt the tally and to either show it or allow
+        downloading it here.
+      </P>
+      <P>TODO: If the tally has already been decrypted, just show it here.</P>
+    </NavigationScreen>
+  );
+}

--- a/apps/cacvote-jx-terminal/frontend/src/screens/voters_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/voters_screen.tsx
@@ -1,13 +1,52 @@
 import { H2, P, TD, TH, Table } from '@votingworks/ui';
-import { DateTime } from 'luxon';
 import { useState } from 'react';
 import * as api from '../api';
+import { RegistrationPresenter } from '../cacvote-server/session_data';
 import { Uuid } from '../cacvote-server/types';
+import { DateTimeCell } from '../components/date_time_cell';
 import {
   ElectionConfiguration,
   ElectionConfigurationSelect,
 } from '../components/election_configuration_select';
+import { RegistrationConfigurationCell } from '../components/registration_configuration_cell';
+import { VoterInfoCell } from '../components/voter_info_cell';
 import { NavigationScreen } from './navigation_screen';
+
+interface RegistrationsTableProps {
+  registrations: readonly RegistrationPresenter[];
+}
+
+function RegistrationsTable({
+  registrations,
+}: RegistrationsTableProps): JSX.Element {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <TH>Voter</TH>
+          <TH>Election Configuration</TH>
+          <TH>Registered</TH>
+        </tr>
+      </thead>
+      <tbody>
+        {registrations.map((r) => (
+          <tr key={r.id}>
+            <VoterInfoCell
+              displayName={r.displayName}
+              commonAccessCardId={r.registration.commonAccessCardId}
+            />
+            <RegistrationConfigurationCell
+              electionTitle={r.electionTitle}
+              ballotStyleId={r.registration.ballotStyleId}
+              precinctId={r.registration.precinctId}
+            />
+            <DateTimeCell dateTime={r.createdAt} />
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}
 
 export function VotersScreen(): JSX.Element | null {
   const sessionDataQuery = api.sessionData.useQuery();
@@ -83,42 +122,7 @@ export function VotersScreen(): JSX.Element | null {
 
       <H2>Registrations</H2>
       {sessionData.registrations.length > 0 ? (
-        <Table>
-          <thead>
-            <tr>
-              <TH>Voter</TH>
-              <TH>Election Configuration</TH>
-              <TH>Registered</TH>
-            </tr>
-          </thead>
-          <tbody>
-            {sessionData.registrations.map((r) => (
-              <tr key={r.id}>
-                <TD>
-                  <P>{r.displayName}</P>
-                  <P>
-                    <em>CAC:</em> {r.registration.commonAccessCardId}
-                  </P>
-                </TD>
-                <TD>
-                  <P>{r.electionTitle}</P>
-                  <P>
-                    <em>Ballot Style:</em> {r.registration.ballotStyleId}
-                    <br />
-                    <em>Precinct:</em> {r.registration.precinctId}
-                  </P>
-                </TD>
-                <TD>
-                  <P>
-                    {DateTime.fromISO(r.createdAt).toLocaleString(
-                      DateTime.DATETIME_SHORT
-                    )}
-                  </P>
-                </TD>
-              </tr>
-            ))}
-          </tbody>
-        </Table>
+        <RegistrationsTable registrations={sessionData.registrations} />
       ) : (
         <p>There are no registrations.</p>
       )}

--- a/libs/types-rs/src/cacvote/mod.rs
+++ b/libs/types-rs/src/cacvote/mod.rs
@@ -566,6 +566,7 @@ pub struct CastBallotPresenter {
     cast_ballot: CastBallot,
     registration_request: RegistrationRequest,
     registration: Registration,
+    registration_id: Uuid,
     verification_status: VerificationStatus,
     #[serde(with = "time::serde::iso8601")]
     created_at: OffsetDateTime,
@@ -576,6 +577,7 @@ impl CastBallotPresenter {
         cast_ballot: CastBallot,
         registration_request: RegistrationRequest,
         registration: Registration,
+        registration_id: Uuid,
         verification_status: VerificationStatus,
         created_at: OffsetDateTime,
     ) -> Self {
@@ -583,6 +585,7 @@ impl CastBallotPresenter {
             cast_ballot,
             registration_request,
             registration,
+            registration_id,
             verification_status,
             created_at,
         }
@@ -590,6 +593,10 @@ impl CastBallotPresenter {
 
     pub fn registration(&self) -> &Registration {
         &self.registration
+    }
+
+    pub fn registration_id(&self) -> &Uuid {
+        &self.registration_id
     }
 
     pub fn registration_request(&self) -> &RegistrationRequest {


### PR DESCRIPTION
The tally screen is just a placeholder for now.

<img width="1502" alt="image" src="https://github.com/votingworks/cacvote/assets/1938/3d6b27d6-4826-4886-a995-dabdc49f30cb">

<img width="1500" alt="image" src="https://github.com/votingworks/cacvote/assets/1938/42f845ba-a88d-442d-aecb-ac5997adeb09">
