### PR TITLE
feat(mark): print serial number on ballot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,6 @@ dependencies = [
  "color-eyre",
  "napi",
  "napi-derive",
- "rand",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ pcsc = "2.8.0"
 pretty_assertions = "1.4.0"
 pretty_env_logger = "0.4.0"
 proptest = "1.2.0"
-rand = "0.8.5"
 rayon = "1.7.0"
 regex = "1.9.1"
 reqwest = { version = "0.11.18", features = ["json"] }

--- a/apps/cacvote-mark/backend/src/app.ts
+++ b/apps/cacvote-mark/backend/src/app.ts
@@ -241,6 +241,7 @@ function buildApi({
 
     castBallot(input: {
       votes: VotesDict;
+      serialNumber: number;
       pin: string;
     }): Promise<
       Result<
@@ -279,7 +280,7 @@ function buildApi({
         const election = electionPayload.getData();
         const electionDefinition = election.getElectionDefinition();
 
-        const ballotId = Uuid();
+        const ballotId = `${input.serialNumber}`;
         const castVoteRecordId = unsafeParse(BallotIdSchema, ballotId);
         const castVoteRecord = buildCastVoteRecord({
           electionDefinition,
@@ -309,7 +310,8 @@ function buildApi({
           registration.registration.getRegistrationRequestObjectId(),
           registration.object.getId(),
           electionObjectId,
-          castVoteRecord
+          castVoteRecord,
+          input.serialNumber
         );
 
         const signature = (

--- a/apps/cacvote-mark/backend/src/electionguard.ts
+++ b/apps/cacvote-mark/backend/src/electionguard.ts
@@ -5,7 +5,7 @@ import {
   extractManifestFromPublicMetadataBlob,
 } from '@votingworks/electionguard';
 import { CVR } from '@votingworks/types';
-import { assertDefined } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import { CastBallot, Election, Payload, Uuid } from './cacvote-server/types';
 
 /**
@@ -19,13 +19,21 @@ export function createEncryptedBallotPayload(
   registrationRequestObjectId: Uuid,
   registrationObjectId: Uuid,
   electionObjectId: Uuid,
-  castVoteRecord: CVR.CVR
+  castVoteRecord: CVR.CVR,
+  serialNumber: number
 ): Payload<CastBallot> {
+  assert(
+    Number.isSafeInteger(serialNumber),
+    'serialNumber must be a safe integer'
+  );
+  assert(serialNumber >= 0, 'serialNumber must be non-negative');
+
   const election = electionPayload.getData();
   const electionMetadataBlob = election.getElectionguardElectionMetadataBlob();
   const manifest = extractManifestFromPublicMetadataBlob(electionMetadataBlob);
   const plaintextBallot = convertVxCvrToEgPlaintextBallot(
     election.getElectionDefinition().election,
+    serialNumber,
     manifest,
     castVoteRecord
   );

--- a/apps/cacvote-mark/frontend/package.json
+++ b/apps/cacvote-mark/frontend/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.6.4",
     "eslint-plugin-vx": "workspace:*",
+    "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",

--- a/apps/cacvote-mark/frontend/src/random.test.ts
+++ b/apps/cacvote-mark/frontend/src/random.test.ts
@@ -1,0 +1,47 @@
+import fc from 'fast-check';
+import { randomInt } from './random';
+
+test('randomInt()', () => {
+  for (let i = 0; i < 1_000; i += 1) {
+    expect(randomInt()).toBeGreaterThanOrEqual(0);
+    expect(randomInt()).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+  }
+});
+
+test('randomInt(number)', () => {
+  fc.assert(
+    fc.property(fc.integer({ min: 0 }), (max) => {
+      const random = randomInt(max);
+      expect(random).toBeGreaterThanOrEqual(0);
+      expect(random).toBeLessThanOrEqual(max);
+      expect(Number.isSafeInteger(random)).toEqual(true);
+    })
+  );
+
+  expect(randomInt(0)).toEqual(0);
+  expect([0, 1]).toContain(randomInt(1));
+  expect(() => randomInt(1.1)).toThrow();
+  expect(() => randomInt(Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  expect(() => randomInt(-1)).toThrow();
+});
+
+test('randomInt(number, number)', () => {
+  fc.assert(
+    fc.property(
+      fc.integer().chain((min) => fc.integer({ min }).map((max) => [min, max])),
+      ([min, max]) => {
+        const random = randomInt(min, max);
+        expect(random).toBeGreaterThanOrEqual(min);
+        expect(random).toBeLessThanOrEqual(max);
+        expect(Number.isSafeInteger(random)).toEqual(true);
+      }
+    )
+  );
+
+  expect(randomInt(0, 0)).toEqual(0);
+  expect([0, 1]).toContain(randomInt(0, 1));
+  expect(() => randomInt(1, 0)).toThrow();
+  expect(() => randomInt(0, 1.1)).toThrow();
+  expect(() => randomInt(-1, Number.MAX_SAFE_INTEGER)).toThrow();
+  expect(() => randomInt(Number.MIN_SAFE_INTEGER, 1)).toThrow();
+});

--- a/apps/cacvote-mark/frontend/src/random.ts
+++ b/apps/cacvote-mark/frontend/src/random.ts
@@ -1,0 +1,31 @@
+import { assert } from '@votingworks/basics';
+
+export function randomInt(): number;
+export function randomInt(max: number): number;
+export function randomInt(min: number, max: number): number;
+export function randomInt(min?: number, max?: number): number {
+  if (typeof min === 'undefined' && typeof max === 'undefined') {
+    return randomInt(0, Number.MAX_SAFE_INTEGER);
+  }
+
+  if (typeof min === 'number' && typeof max === 'undefined') {
+    return randomInt(0, min);
+  }
+
+  assert(typeof min === 'number' && typeof max === 'number');
+  assert(min <= max, 'min must be less than or equal to max');
+  assert(Number.isSafeInteger(min), 'min must be a safe integer');
+  assert(Number.isSafeInteger(max), 'max must be a safe integer');
+
+  if (min === max) {
+    return min;
+  }
+
+  const range = max - min;
+  assert(Number.isSafeInteger(range), 'max - min must be a safe integer');
+
+  const buffer = crypto.getRandomValues(new Uint32Array(2));
+  const random = buffer[0] * 0x100000000 + buffer[1];
+
+  return min + (random % (range + 1));
+}

--- a/apps/cacvote-mark/frontend/src/screens/voter_flow_screen.tsx
+++ b/apps/cacvote-mark/frontend/src/screens/voter_flow_screen.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { getElectionConfiguration, getVoterStatus } from '../api';
 import * as Registration from './registration';
 import * as Voting from './voting';
+import { randomInt } from '../random';
 
 interface InitState {
   type: 'init';
@@ -29,16 +30,19 @@ interface ReviewOnscreenState {
 interface PrintBallotState {
   type: 'print_ballot';
   votes: VotesDict;
+  serialNumber: number;
 }
 
 interface ReviewPrintedBallotState {
   type: 'review_printed';
   votes: VotesDict;
+  serialNumber: number;
 }
 
 interface SubmitState {
   type: 'submit';
   votes: VotesDict;
+  serialNumber: number;
 }
 
 interface PostVoteState {
@@ -109,9 +113,11 @@ function RegisteredStateScreen({
   function onReviewConfirm() {
     setVoterFlowState((prev) => {
       assert(prev?.type === 'review_onscreen');
+      const serialNumber = randomInt();
       return {
         type: 'print_ballot',
         votes: prev.votes,
+        serialNumber,
       };
     });
   }
@@ -172,6 +178,7 @@ function RegisteredStateScreen({
       return {
         type: 'review_printed',
         votes: prev.votes,
+        serialNumber: prev.serialNumber,
       };
     });
   }
@@ -182,6 +189,7 @@ function RegisteredStateScreen({
       return {
         type: 'submit',
         votes: prev.votes,
+        serialNumber: prev.serialNumber,
       };
     });
   }
@@ -260,7 +268,7 @@ function RegisteredStateScreen({
           ballotStyleId={ballotStyleId}
           precinctId={precinctId}
           votes={voterFlowState.votes}
-          generateBallotId={() => ''}
+          generateBallotId={() => `${voterFlowState.serialNumber}`}
           // TODO: use live vs test mode?
           isLiveMode={false}
           onPrintCompleted={onPrintBallotCompleted}
@@ -279,6 +287,7 @@ function RegisteredStateScreen({
       return (
         <Voting.SubmitScreen
           votes={voterFlowState.votes}
+          serialNumber={voterFlowState.serialNumber}
           onSubmitted={onSubmitted}
         />
       );

--- a/apps/cacvote-mark/frontend/src/screens/voting/submit_screen.tsx
+++ b/apps/cacvote-mark/frontend/src/screens/voting/submit_screen.tsx
@@ -15,11 +15,13 @@ import { COMMON_ACCESS_CARD_PIN_LENGTH } from '../../globals';
 
 export interface SubmitScreenProps {
   votes: VotesDict;
+  serialNumber: number;
   onSubmitted: () => void;
 }
 
 export function SubmitScreen({
   votes,
+  serialNumber,
   onSubmitted,
 }: SubmitScreenProps): JSX.Element {
   const [isShowingPinModal, setIsShowingPinModal] = useState(false);
@@ -28,7 +30,7 @@ export function SubmitScreen({
   const isCheckingPin = castBallotMutation.isLoading;
 
   function submitBallot(pin: string) {
-    castBallotMutationMutate({ votes, pin });
+    castBallotMutationMutate({ votes, serialNumber, pin });
   }
 
   useEffect(() => {

--- a/libs/electionguard-rs/Cargo.toml
+++ b/libs/electionguard-rs/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 color-eyre = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/libs/electionguard-rs/src/ballot.rs
+++ b/libs/electionguard-rs/src/ballot.rs
@@ -1,12 +1,10 @@
 use std::{
     fs::{read_dir, DirBuilder, File},
     io::{self, Read},
-    ops::Range,
     path::PathBuf,
 };
 
 use color_eyre::eyre::{bail, ensure};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use types_rs::{
     cdf::cvr::{AllocationStatus, Cvr},
@@ -19,10 +17,6 @@ use crate::{
     manifest::{Manifest, ObjectId},
     zip::{unzip_into_directory, UnzipLimits},
 };
-
-/// The range of serial numbers for ballots. Max is `Number.MAX_SAFE_INTEGER`
-/// from JS.
-pub(crate) const SERIAL_NUMBER_RANGE: Range<u64> = 1..((2 ^ 53) - 1);
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -53,6 +47,7 @@ pub struct Selection {
 
 pub fn convert_vx_cvr_to_eg_plaintext_ballot(
     cvr: Cvr,
+    serial_number: u64,
     manifest: Manifest,
     election: election::Election,
 ) -> color_eyre::Result<PlaintextBallot> {
@@ -163,7 +158,7 @@ pub fn convert_vx_cvr_to_eg_plaintext_ballot(
         ballot_id: ObjectId(unique_id),
         ballot_style: eg_ballot_style.object_id.clone(),
         contests,
-        sn: Some(rand::thread_rng().gen_range(SERIAL_NUMBER_RANGE)),
+        sn: Some(serial_number),
         errors: None,
     };
 
@@ -288,7 +283,7 @@ mod tests {
                 ballot_id: ObjectId("ballot1".to_owned()),
                 ballot_style: manifest.ballot_styles[0].object_id.clone(),
                 contests: vec![],
-                sn: Some(rand::thread_rng().gen_range(SERIAL_NUMBER_RANGE)),
+                sn: Some(1234567890),
                 errors: None,
             };
 

--- a/libs/electionguard-rs/src/mixnet.rs
+++ b/libs/electionguard-rs/src/mixnet.rs
@@ -112,14 +112,13 @@ pub fn run_mixnet(
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
     use types_rs::election::ElectionDefinition;
 
     use super::*;
     use std::{iter::once, num::NonZeroUsize};
 
     use crate::{
-        ballot::{encrypt, PlaintextBallot, SERIAL_NUMBER_RANGE},
+        ballot::{encrypt, PlaintextBallot},
         config::generate_election_config,
         manifest::{Manifest, ObjectId},
     };
@@ -147,7 +146,7 @@ mod tests {
             ballot_id: ObjectId("ballot1".to_owned()),
             ballot_style: manifest.ballot_styles[0].object_id.clone(),
             contests: vec![],
-            sn: Some(rand::thread_rng().gen_range(SERIAL_NUMBER_RANGE)),
+            sn: Some(1234567890),
             errors: None,
         };
 
@@ -201,7 +200,7 @@ mod tests {
             ballot_id: ObjectId("ballot1".to_owned()),
             ballot_style: manifest.ballot_styles[0].object_id.clone(),
             contests: vec![],
-            sn: Some(rand::thread_rng().gen_range(SERIAL_NUMBER_RANGE)),
+            sn: Some(1234567890),
             errors: None,
         };
 

--- a/libs/electionguard/index.test.ts
+++ b/libs/electionguard/index.test.ts
@@ -62,6 +62,7 @@ test('convert VX CVR to EG plaintext ballot', () => {
   const manifest = convertVxElectionToEgManifest(famousNamesElection);
   const egPlaintextBallot = convertVxCvrToEgPlaintextBallot(
     famousNamesElection,
+    0,
     manifest,
     famousNamesCvr
   );
@@ -85,6 +86,7 @@ test('convert VX CVR to EG plaintext ballot', () => {
   const config = generateElectionConfig(assertDefined(EG_CLASSPATH), manifest);
   const egPlaintextBallot = convertVxCvrToEgPlaintextBallot(
     famousNamesElection,
+    0,
     manifest,
     famousNamesCvr
   );

--- a/libs/electionguard/napi.d.ts
+++ b/libs/electionguard/napi.d.ts
@@ -20,7 +20,7 @@ export function generateElectionConfig(classpath: string, egManifest: import('./
  * `vx_election` argument. The return value is the EG plaintext ballot as a
  * POJO.
  */
-export function convertVxCvrToEgPlaintextBallot(vxElection: import('@votingworks/types').Election, egManifest: import('./types').Manifest, vxCvr: import('@votingworks/types').CVR.CVR): import('./types').PlaintextBallot
+export function convertVxCvrToEgPlaintextBallot(vxElection: import('@votingworks/types').Election, serialNumber: number, egManifest: import('./types').Manifest, vxCvr: import('@votingworks/types').CVR.CVR): import('./types').PlaintextBallot
 /**
  * Encrypt an EG plaintext ballot using the ElectionGuard Java implementation.
  * The `classpath` argument should be the path to the ElectionGuard Java JAR

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,9 @@ importers:
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
+      fast-check:
+        specifier: 2.23.2
+        version: 2.23.2
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0


### PR DESCRIPTION
Changes the ElectionGuard API to require passing a serial number, which is now generated on the frontend.
