### PR TITLE
feat(mark): QR code updates

### DIFF
--- a/apps/cacvote-mark/backend/src/app.ts
+++ b/apps/cacvote-mark/backend/src/app.ts
@@ -329,6 +329,7 @@ function buildApi({
 
         const signatureHash = createHash('sha256').update(signature).digest();
         const ballotValidationPayload = new BallotVerificationPayload(
+          VX_MACHINE_ID,
           commonAccessCardId,
           electionObjectId,
           signatureHash

--- a/apps/cacvote-mark/backend/src/verification.test.ts
+++ b/apps/cacvote-mark/backend/src/verification.test.ts
@@ -11,11 +11,13 @@ function arbitrarySha256() {
 test(BallotVerificationPayload.name, () => {
   fc.assert(
     fc.property(
-      fc.string({ minLength: 10, maxLength: 10 }),
+      fc.string({ minLength: 2, maxLength: 10 }), // machineId
+      fc.string({ minLength: 10, maxLength: 10 }), // commonAccessCardId
       fc.uuid(),
       arbitrarySha256(),
-      (commonAccessCardId, electionObjectId, signatureHash) => {
+      (machineId, commonAccessCardId, electionObjectId, signatureHash) => {
         const original = new BallotVerificationPayload(
+          machineId,
           commonAccessCardId,
           unsafeParse(UuidSchema, electionObjectId),
           Buffer.from(signatureHash)

--- a/apps/cacvote-mark/backend/src/verification.ts
+++ b/apps/cacvote-mark/backend/src/verification.ts
@@ -2,6 +2,7 @@
 import { constructTlv, parseTlvList } from '@votingworks/auth';
 import { unsafeParse } from '@votingworks/types';
 import { Buffer } from 'buffer';
+import * as uuid from 'uuid';
 import { Uuid, UuidSchema } from './cacvote-server/types';
 
 /**
@@ -41,7 +42,7 @@ export class BallotVerificationPayload {
       ),
       constructTlv(
         BallotVerificationPayload.ELECTION_OBJECT_ID_TAG,
-        Buffer.from(this.electionObjectId)
+        Buffer.from(uuid.parse(this.electionObjectId))
       ),
       constructTlv(
         BallotVerificationPayload.ENCRYPTED_BALLOT_SIGNATURE_HASH_TAG,
@@ -68,7 +69,7 @@ export class BallotVerificationPayload {
     const commonAccessCardId = commonAccessCardIdBytes.toString('utf-8');
     const electionObjectId = unsafeParse(
       UuidSchema,
-      electionObjectIdBytes.toString('utf-8')
+      uuid.stringify(electionObjectIdBytes)
     );
 
     const signatureHash = signatureHashBytes;


### PR DESCRIPTION
## Overview

- Use binary UUID encoding
- Add `machineId` to the ballot verification payload