### PR TITLE
feat(libs): add `tlv` and `tlv-derive` libs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,6 +805,34 @@ jobs:
           command: |
             cargo test -p electionguard-rs
 
+  test-crate-tlv:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            cargo build -p tlv
+      - run:
+          name: Test
+          command: |
+            cargo test -p tlv
+
+  test-crate-tlv-derive:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install
+      - run:
+          name: Build
+          command: |
+            cargo build -p tlv-derive
+      - run:
+          name: Test
+          command: |
+            cargo test -p tlv-derive
+
   test-crate-types-rs:
     executor: nodejs
     resource_class: xlarge
@@ -885,6 +913,8 @@ workflows:
       - test-crate-cacvote-server
       - test-crate-electionguard
       - test-crate-electionguard-rs
+      - test-crate-tlv
+      - test-crate-tlv-derive
       - test-crate-types-rs
       - test-crate-vx-logging
       - validate-monorepo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -614,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -894,7 +894,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1360,7 +1360,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1404,7 +1404,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ dependencies = [
  "quote",
  "regex",
  "semver",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1576,7 +1576,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1712,7 +1712,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1839,9 +1839,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2154,7 +2154,7 @@ checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2536,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2608,7 +2608,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2666,6 +2666,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tlv"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
+name = "tlv-derive"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "quote",
+ "syn 2.0.63",
+ "tlv",
+]
+
+[[package]]
 name = "tokio"
 version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,7 +2707,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2802,7 +2819,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3047,7 +3064,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
@@ -3081,7 +3098,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3301,7 +3318,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.63",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ name = "tlv"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "uuid",
 ]
 
 [[package]]
@@ -2902,6 +2903,8 @@ dependencies = [
  "serde_json",
  "sqlx",
  "time",
+ "tlv",
+ "tlv-derive",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ openssl = "0.10.56"
 pcsc = "2.8.0"
 pretty_assertions = "1.4.0"
 pretty_env_logger = "0.4.0"
-proptest = "1.2.0"
+proptest = "1.4.0"
 rayon = "1.7.0"
 regex = "1.9.1"
 reqwest = { version = "0.11.18", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,14 @@
 resolver = "2"
 members = [
     "apps/cacvote-jx-terminal/backend",
+    "apps/cacvote-server/backend",
     "libs/auth-rs",
     "libs/electionguard",
     "libs/electionguard-rs",
     "libs/logging",
+    "libs/tlv",
+    "libs/tlv-derive",
     "libs/types-rs",
-    "apps/cacvote-server/backend",
 ]
 
 [workspace.dependencies]
@@ -63,6 +65,8 @@ sha256 = "1.2.2"
 tempfile = "3.3.0"
 thiserror = "1.0.50"
 time = { version = "0.3.22", features = ["formatting", "parsing", "serde"] }
+tlv = { path = "libs/tlv" }
+tlv-derive = { path = "libs/tlv-derive" }
 tokio = { version = "1.29.1", default-features = false, features = [
     "sync",
     "macros",

--- a/libs/tlv-derive/Cargo.toml
+++ b/libs/tlv-derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tlv-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+quote = "1.0.36"
+syn = "2.0.63"
+tlv = { workspace = true }
+
+[dev-dependencies]
+proptest = "1.4.0"

--- a/libs/tlv-derive/README.md
+++ b/libs/tlv-derive/README.md
@@ -1,0 +1,35 @@
+# `tlv-derive`
+
+This crate provides derive macros for the `tlv` crate.
+
+# Example
+
+```rust
+use tlv::{Decode, Encode};
+use tlv_derive::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Decode, Encode)]
+struct Test {
+    #[tlv(tag = 0x20)]
+    a: u8,
+    #[tlv(tag = 0x21)]
+    b: u16,
+}
+
+fn main() -> std::io::Result<()> {
+    let value = Test { a: 0x99, b: 0xabcd };
+    let encoded = tlv::to_vec(&value)?;
+    assert_eq!(encoded, [
+        0x20, // `value.a` tag
+        0x01, // `value.a` length
+        0x99, // `value.a` value
+        0x21, // `value.b` tag
+        0x02, // `value.b` length
+        0xab, // `value.b` value
+        0xcd  // `value.b` value
+    ]);
+    let decoded: Test = tlv::from_slice(&encoded)?;
+    assert_eq!(decoded, value);
+    Ok(())
+}
+```

--- a/libs/tlv-derive/src/lib.rs
+++ b/libs/tlv-derive/src/lib.rs
@@ -1,0 +1,152 @@
+//! This crate provides procedural macros for the `tlv` crate. The macros are
+//! used to derive the `Encode` and `Decode` traits for structs. The `Encode`
+//! trait is used to encode a struct into a TLV format. The `Decode` trait is
+//! used to decode a struct from a TLV format.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, spanned::Spanned, DeriveInput};
+
+/// Generates an implementation of the `Encode` trait for the annotated struct.
+/// The implementation will encode the struct into a TLV format.
+#[proc_macro_derive(Encode, attributes(tlv))]
+pub fn encode_derive(input: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let DeriveInput { ident, data, .. } = parse_macro_input!(input);
+
+    let name = ident;
+    let entities = match data {
+        syn::Data::Struct(data) => match data.fields {
+            syn::Fields::Named(fields) => fields
+                .named
+                .into_iter()
+                .map(|f| parse_field_tlv_entity(&f).unwrap())
+                .collect::<Vec<_>>(),
+            _ => panic!("only named fields are supported"),
+        },
+        _ => panic!("only structs are supported"),
+    };
+    let tags = entities
+        .iter()
+        .map(|e| match e.tag {
+            tlv::Tag::U8(tag) => quote! { tlv::Tag::U8(#tag) },
+            tlv::Tag::U16(tag) => quote! { tlv::Tag::U16(#tag) },
+        })
+        .collect::<Vec<_>>();
+    let idents = entities.iter().map(|e| &e.ident).collect::<Vec<_>>();
+    let gen = quote! {
+        impl tlv::Encode for #name {
+            fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+            where
+                W: std::io::Write,
+            {
+                #(tlv::value::encode_tagged(#tags, &self.#idents, writer)?;)*
+                Ok(())
+            }
+
+            fn encoded_length(&self) -> std::io::Result<tlv::Length> {
+                let mut length = tlv::Length::new(0);
+                #(length += tlv::value::length_tagged(#tags, &self.#idents)?;)*
+                Ok(length)
+            }
+        }
+    };
+    gen.into()
+}
+
+/// Generates an implementation of the `Decode` trait for the annotated struct.
+/// The implementation will decode the struct from a TLV format.
+#[proc_macro_derive(Decode, attributes(tlv))]
+pub fn decode_derive(input: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let DeriveInput { ident, data, .. } = parse_macro_input!(input);
+
+    let name = ident;
+    let entities = match data {
+        syn::Data::Struct(data) => match data.fields {
+            syn::Fields::Named(fields) => fields
+                .named
+                .into_iter()
+                .map(|f| parse_field_tlv_entity(&f).unwrap())
+                .collect::<Vec<_>>(),
+            _ => panic!("only named fields are supported"),
+        },
+        _ => panic!("only structs are supported"),
+    };
+    let tags = entities.iter().map(|e| match e.tag {
+        tlv::Tag::U8(tag) => quote! { tlv::Tag::U8(#tag) },
+        tlv::Tag::U16(tag) => quote! { tlv::Tag::U16(#tag) },
+    });
+    let idents = entities.iter().map(|e| &e.ident).collect::<Vec<_>>();
+    let gen = quote! {
+        impl tlv::Decode for #name {
+            fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+            where
+                R: std::io::Read
+            {
+                let __tlv_decode_read: usize = 0;
+                #(
+                    let (#idents, __tlv_decode_read) = match tlv::value::decode_tagged(#tags, reader)? {
+                        (value, read) => (value, read + __tlv_decode_read),
+                    };
+                )*
+                Ok((Self { #(#idents),* }, __tlv_decode_read))
+            }
+        }
+    };
+    gen.into()
+}
+
+#[derive(Debug)]
+struct TlvEntity {
+    ident: syn::Ident,
+    tag: tlv::Tag,
+}
+
+fn parse_field_tlv_entity(field: &syn::Field) -> Result<TlvEntity, syn::Error> {
+    let tlv_attr = field
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("tlv"))
+        .ok_or_else(|| {
+            syn::Error::new(
+                field.span(),
+                "missing tlv attribute on field, expected #[tlv(tag = <tag>)]",
+            )
+        })?;
+
+    let mut tag: Option<u16> = None;
+
+    tlv_attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("tag") {
+            let value = meta.value()?;
+            let lit: syn::LitInt = value.parse()?;
+            tag = Some(lit.base10_parse()?);
+            Ok(())
+        } else {
+            Err(syn::Error::new(meta.path.span(), "expected tag attribute"))
+        }
+    })?;
+
+    let tag = match tag {
+        Some(tag) if tag <= u8::MAX as u16 => tlv::Tag::U8(tag as u8),
+        Some(tag) => tlv::Tag::U16(tag),
+        None => {
+            return Err(syn::Error::new(
+                tlv_attr.span(),
+                "missing tag attribute on field, expected #[tlv(tag = <tag>)]",
+            ))
+        }
+    };
+
+    let ident = field.ident.clone().ok_or_else(|| {
+        syn::Error::new(
+            field.span(),
+            "missing field identifier, expected named fields",
+        )
+    })?;
+
+    Ok(TlvEntity { ident, tag })
+}

--- a/libs/tlv-derive/src/lib.rs
+++ b/libs/tlv-derive/src/lib.rs
@@ -82,6 +82,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
     let idents = entities.iter().map(|e| &e.ident).collect::<Vec<_>>();
     let gen = quote! {
         impl tlv::Decode for #name {
+            #[allow(clippy::match_single_binding)]
             fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
             where
                 R: std::io::Read

--- a/libs/tlv-derive/src/lib.rs
+++ b/libs/tlv-derive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
     let idents = entities.iter().map(|e| &e.ident).collect::<Vec<_>>();
     let gen = quote! {
         impl tlv::Encode for #name {
-            fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+            fn encode<W>(&self, writer: &mut W) -> tlv::Result<()>
             where
                 W: std::io::Write,
             {
@@ -45,7 +45,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
                 Ok(())
             }
 
-            fn encoded_length(&self) -> std::io::Result<tlv::Length> {
+            fn encoded_length(&self) -> tlv::Result<tlv::Length> {
                 let mut length = tlv::Length::new(0);
                 #(length += tlv::value::length_tagged(#tags, &self.#idents)?;)*
                 Ok(length)
@@ -83,7 +83,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
     let gen = quote! {
         impl tlv::Decode for #name {
             #[allow(clippy::match_single_binding)]
-            fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+            fn decode<R>(reader: &mut R) -> tlv::Result<(Self, usize)>
             where
                 R: std::io::Read
             {

--- a/libs/tlv-derive/tests/integration_tests.rs
+++ b/libs/tlv-derive/tests/integration_tests.rs
@@ -1,0 +1,104 @@
+use proptest::proptest;
+use tlv::Encode;
+use tlv_derive::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct Test {
+    #[tlv(tag = 0x99)]
+    a: u8,
+    #[tlv(tag = 0x00)]
+    b: u16,
+    #[tlv(tag = 0x01)]
+    c: u32,
+    #[tlv(tag = 0x02)]
+    d: u64,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct Nesting {
+    #[tlv(tag = 0x99)]
+    a: u8,
+    #[tlv(tag = 0x00)]
+    b: Test,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct StringContainer {
+    #[tlv(tag = 0x00)]
+    s: String,
+}
+
+#[test]
+fn test_derive() {
+    let value = Test {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+    };
+    let encoded = tlv::to_vec(&value).unwrap();
+    assert_eq!(
+        value.encoded_length().unwrap().value(),
+        encoded.len() as u16
+    );
+
+    assert_eq!(
+        encoded,
+        [
+            /* a TAG = */ 0x99, /* a LENGTH = */ 0x01, /* a VALUE = */ 0x01,
+            /* b TAG = */ 0x00, /* b LENGTH = */ 0x02, /* b VALUE = */ 0x00, 0x02,
+            /* c TAG = */ 0x01, /* c LENGTH = */ 0x04, /* c VALUE = */ 0x00, 0x00,
+            0x00, 0x03, /* d TAG = */ 0x02, /* d LENGTH = */ 0x08, /* d VALUE = */
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
+        ]
+    );
+
+    let decoded_value: Test = tlv::from_slice(&encoded).unwrap();
+    assert_eq!(decoded_value, value);
+}
+
+#[test]
+fn test_nesting() {
+    let value = Nesting {
+        a: 1,
+        b: Test {
+            a: 2,
+            b: 3,
+            c: 4,
+            d: 5,
+        },
+    };
+    let encoded = tlv::to_vec(&value).unwrap();
+    assert_eq!(
+        value.encoded_length().unwrap().value(),
+        encoded.len() as u16
+    );
+
+    assert_eq!(
+        encoded,
+        [
+            /* a TAG = */ 0x99, /* a LENGTH = */ 0x01, /* a VALUE = */ 0x01,
+            /* b TAG = */ 0x00, /* b LENGTH = */ 0x17, /* b VALUE = */
+            /* b.a TAG = */ 0x99, /* b.a LENGTH = */ 0x01, /* b.a VALUE = */ 0x02,
+            /* b.b TAG = */ 0x00, /* b.b LENGTH = */ 0x02, /* b.b VALUE = */ 0x00,
+            0x03, /* b.c TAG = */ 0x01, /* b.c LENGTH = */ 0x04,
+            /* b.c VALUE = */ 0x00, 0x00, 0x00, 0x04, /* b.d TAG = */ 0x02,
+            /* b.d LENGTH = */ 0x08, /* b.d VALUE = */
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05,
+        ]
+    );
+
+    let decoded_value: Nesting = tlv::from_slice(&encoded).unwrap();
+    assert_eq!(decoded_value, value);
+}
+
+proptest! {
+    #[test]
+    fn test_string(s: String) {
+        let value = StringContainer { s };
+        let encoded = tlv::to_vec(&value).unwrap();
+
+        let decoded_value: StringContainer = tlv::from_slice(&encoded).unwrap();
+        assert_eq!(decoded_value, value);
+    }
+}

--- a/libs/tlv/Cargo.toml
+++ b/libs/tlv/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uuid = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.4.0"
+proptest = { workspace = true }

--- a/libs/tlv/Cargo.toml
+++ b/libs/tlv/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thiserror = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/libs/tlv/Cargo.toml
+++ b/libs/tlv/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tlv"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[dev-dependencies]
+proptest = "1.4.0"

--- a/libs/tlv/src/coder.rs
+++ b/libs/tlv/src/coder.rs
@@ -1,0 +1,165 @@
+use std::io::{Read, Write};
+
+use crate::length::Length;
+
+/// Encodes a value into a writer.
+pub trait Encode {
+    /// Converts the value into a byte representation and writes it to the
+    /// writer.
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: Write;
+
+    /// Returns the length of the encoded value.
+    fn encoded_length(&self) -> std::io::Result<Length>;
+}
+
+/// Decodes a value from a decoder.
+pub trait Decode
+where
+    Self: Sized,
+{
+    /// Reads the value from the decoder.
+    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    where
+        R: Read;
+}
+
+macro_rules! impl_coders {
+    ($($t:ty),*) => {
+        $(
+            impl Encode for $t {
+                fn encode<W>(&self, writer: &mut W) -> std::io::Result<()> where W: Write {
+                    writer.write_all(&self.to_be_bytes())
+                }
+
+                fn encoded_length(&self) -> std::io::Result<Length> {
+                    Ok(Length::new(std::mem::size_of::<$t>() as u16))
+                }
+            }
+
+            impl Decode for $t {
+                fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)> where R: Read {
+                    const SIZE: usize = std::mem::size_of::<$t>();
+                    let mut buf = [0; SIZE];
+                    reader.read_exact(&mut buf)?;
+                    Ok((<$t>::from_be_bytes(buf), SIZE))
+                }
+            }
+        )*
+    };
+}
+
+impl_coders!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
+
+impl<T: Encode> Encode for &T {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        (*self).encode(writer)
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        (*self).encoded_length()
+    }
+}
+
+impl Encode for bool {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        (*self as u8).encode(writer)
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        <u8 as Encode>::encoded_length(&(*self as u8))
+    }
+}
+
+impl Encode for [u8] {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        if self.len() > u16::MAX as usize {
+            return Err(std::io::ErrorKind::InvalidData.into());
+        }
+
+        writer.write_all(self)
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        if self.len() > u16::MAX as usize {
+            Err(std::io::ErrorKind::InvalidData.into())
+        } else {
+            Ok(Length::new(self.len() as u16))
+        }
+    }
+}
+
+impl Encode for Vec<u8> {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        self.as_slice().encode(writer)
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        <[u8] as Encode>::encoded_length(self)
+    }
+}
+
+impl Encode for String {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        writer.write_all(self.as_bytes())
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        if self.len() > u16::MAX as usize {
+            Err(std::io::ErrorKind::InvalidData.into())
+        } else {
+            Ok(Length::new(self.len() as u16))
+        }
+    }
+}
+
+impl Decode for Vec<u8> {
+    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    where
+        R: Read,
+    {
+        let mut data = Vec::new();
+        reader.read_to_end(&mut data)?;
+        let len = data.len();
+        Ok((data, len))
+    }
+}
+
+impl Decode for String {
+    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    where
+        R: Read,
+    {
+        Vec::<u8>::decode(reader).and_then(|(data, read)| {
+            match std::string::String::from_utf8(data) {
+                Ok(string) => Ok((string, read)),
+                Err(_) => Err(std::io::ErrorKind::InvalidData.into()),
+            }
+        })
+    }
+}
+
+impl Decode for () {
+    fn decode<R>(_reader: &mut R) -> std::io::Result<(Self, usize)>
+    where
+        R: Read,
+    {
+        Ok(((), 0))
+    }
+}

--- a/libs/tlv/src/coder.rs
+++ b/libs/tlv/src/coder.rs
@@ -1,17 +1,18 @@
 use std::io::{Read, Write};
 
+use crate::error::{Error, Result};
 use crate::length::Length;
 
 /// Encodes a value into a writer.
 pub trait Encode {
     /// Converts the value into a byte representation and writes it to the
     /// writer.
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write;
 
     /// Returns the length of the encoded value.
-    fn encoded_length(&self) -> std::io::Result<Length>;
+    fn encoded_length(&self) -> Result<Length>;
 }
 
 /// Decodes a value from a decoder.
@@ -20,7 +21,7 @@ where
     Self: Sized,
 {
     /// Reads the value from the decoder.
-    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read;
 }
@@ -29,17 +30,17 @@ macro_rules! impl_coders {
     ($($t:ty),*) => {
         $(
             impl Encode for $t {
-                fn encode<W>(&self, writer: &mut W) -> std::io::Result<()> where W: Write {
-                    writer.write_all(&self.to_be_bytes())
+                fn encode<W>(&self, writer: &mut W) -> Result<()> where W: Write {
+                    Ok(writer.write_all(&self.to_be_bytes())?)
                 }
 
-                fn encoded_length(&self) -> std::io::Result<Length> {
+                fn encoded_length(&self) -> Result<Length> {
                     Ok(Length::new(std::mem::size_of::<$t>() as u16))
                 }
             }
 
             impl Decode for $t {
-                fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)> where R: Read {
+                fn decode<R>(reader: &mut R) -> Result<(Self, usize)> where R: Read {
                     const SIZE: usize = std::mem::size_of::<$t>();
                     let mut buf = [0; SIZE];
                     reader.read_exact(&mut buf)?;
@@ -53,33 +54,33 @@ macro_rules! impl_coders {
 impl_coders!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
 
 impl<T: Encode> Encode for &T {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
         (*self).encode(writer)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         (*self).encoded_length()
     }
 }
 
 impl Encode for bool {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
         (*self as u8).encode(writer)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         <u8 as Encode>::encoded_length(&(*self as u8))
     }
 }
 
 impl Decode for bool {
-    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read,
     {
@@ -88,37 +89,39 @@ impl Decode for bool {
 }
 
 impl Encode for [u8] {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
-        u16::try_from(self.len())
-            .map_err(|_| std::io::ErrorKind::InvalidData.into())
-            .and_then(|_| writer.write_all(self))
+        match u16::try_from(self.len()) {
+            Ok(_) => Ok(writer.write_all(self)?),
+            Err(_) => Err(Error::ValueTooLong(self.len())),
+        }
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
-        u16::try_from(self.len())
-            .map(Length::new)
-            .map_err(|_| std::io::ErrorKind::InvalidData.into())
+    fn encoded_length(&self) -> Result<Length> {
+        match u16::try_from(self.len()) {
+            Ok(len) => Ok(Length::new(len)),
+            Err(_) => Err(Error::ValueTooLong(self.len())),
+        }
     }
 }
 
 impl<const N: usize> Encode for [u8; N] {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
-        writer.write_all(self)
+        Ok(writer.write_all(self)?)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         Ok(Length::new(N as u16))
     }
 }
 
 impl<const N: usize> Decode for [u8; N] {
-    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read,
     {
@@ -129,20 +132,20 @@ impl<const N: usize> Decode for [u8; N] {
 }
 
 impl Encode for Vec<u8> {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
         self.as_slice().encode(writer)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         <[u8] as Encode>::encoded_length(self)
     }
 }
 
 impl Decode for Vec<u8> {
-    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read,
     {
@@ -154,36 +157,33 @@ impl Decode for Vec<u8> {
 }
 
 impl Encode for String {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
-        writer.write_all(self.as_bytes())
+        Ok(writer.write_all(self.as_bytes())?)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
-        u16::try_from(self.len())
-            .map(Length::new)
-            .map_err(|_| std::io::ErrorKind::InvalidData.into())
+    fn encoded_length(&self) -> Result<Length> {
+        match u16::try_from(self.len()) {
+            Ok(len) => Ok(Length::new(len)),
+            Err(_) => Err(Error::ValueTooLong(self.len())),
+        }
     }
 }
 
 impl Decode for String {
-    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read,
     {
-        Vec::<u8>::decode(reader).and_then(|(data, read)| {
-            match std::string::String::from_utf8(data) {
-                Ok(string) => Ok((string, read)),
-                Err(_) => Err(std::io::ErrorKind::InvalidData.into()),
-            }
-        })
+        let (data, read) = Vec::<u8>::decode(reader)?;
+        Ok((std::string::String::from_utf8(data)?, read))
     }
 }
 
 impl Decode for () {
-    fn decode<R>(_reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(_reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read,
     {
@@ -194,22 +194,29 @@ impl Decode for () {
 const UUID_BYTES: usize = std::mem::size_of::<uuid::Bytes>();
 
 impl Encode for uuid::Uuid {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: Write,
     {
         let bytes = self.as_bytes();
-        assert_eq!(bytes.len(), UUID_BYTES);
-        writer.write_all(bytes)
+
+        if bytes.len() != UUID_BYTES {
+            return Err(Error::InvalidLength {
+                expected: UUID_BYTES,
+                actual: bytes.len(),
+            });
+        }
+
+        Ok(writer.write_all(bytes)?)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         Ok(Length::new(UUID_BYTES as u16))
     }
 }
 
 impl Decode for uuid::Uuid {
-    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
+    fn decode<R>(reader: &mut R) -> Result<(Self, usize)>
     where
         R: Read,
     {

--- a/libs/tlv/src/error.rs
+++ b/libs/tlv/src/error.rs
@@ -1,0 +1,23 @@
+use std::string::FromUtf8Error;
+
+/// Error type for TLV operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Invalid length: expected {expected}, actual {actual}")]
+    InvalidLength { expected: usize, actual: usize },
+
+    #[error("Invalid tag: expected {expected:?}, actual {actual:?}")]
+    InvalidTag { expected: Vec<u8>, actual: Vec<u8> },
+
+    #[error("Value too long: {0} bytes > u16::MAX")]
+    ValueTooLong(usize),
+
+    #[error("UTF-8 error: {0}")]
+    Utf8Error(#[from] FromUtf8Error),
+}
+
+/// Result type for TLV operations.
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/libs/tlv/src/length.rs
+++ b/libs/tlv/src/length.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use crate::Encode;
+use crate::{Encode, Result};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Length {
@@ -17,7 +17,7 @@ impl Length {
         Self { length }
     }
 
-    pub fn from_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+    pub fn from_reader<R: Read>(reader: &mut R) -> Result<Self> {
         let mut buf = [0; 1];
         reader.read_exact(&mut buf)?;
 
@@ -62,15 +62,15 @@ impl Length {
 }
 
 impl Encode for Length {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: std::io::prelude::Write,
     {
         let bytes: Vec<u8> = self.to_vec();
-        writer.write_all(&bytes)
+        Ok(writer.write_all(&bytes)?)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         let bytes: Vec<u8> = self.to_vec();
         Ok(Length::new(bytes.len() as u16))
     }

--- a/libs/tlv/src/length.rs
+++ b/libs/tlv/src/length.rs
@@ -1,0 +1,91 @@
+use std::io::Read;
+
+use crate::Encode;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Length {
+    length: u16,
+}
+
+impl Length {
+    const MEDIUM_LENGTH_MINIMUM: u16 = 0x81;
+    const MEDIUM_LENGTH_MAXIMUM: u16 = 0xff;
+    const MEDIUM_LENGTH_TOKEN: u8 = 0x81;
+    const LONG_LENGTH_TOKEN: u8 = 0x82;
+
+    pub fn new(length: u16) -> Self {
+        Self { length }
+    }
+
+    pub fn from_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut buf = [0; 1];
+        reader.read_exact(&mut buf)?;
+
+        match buf[0] {
+            Self::MEDIUM_LENGTH_TOKEN => {
+                let mut buf = [0; 1];
+                reader.read_exact(&mut buf)?;
+                Ok(Self::new(u16::from(buf[0])))
+            }
+            Self::LONG_LENGTH_TOKEN => {
+                let mut buf = [0; 2];
+                reader.read_exact(&mut buf)?;
+                Ok(Self::new(u16::from_be_bytes(buf)))
+            }
+            length => Ok(Self::new(u16::from(length))),
+        }
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let length = self.value();
+
+        if length < Length::MEDIUM_LENGTH_MINIMUM {
+            vec![length as u8]
+        } else if length < Length::MEDIUM_LENGTH_MAXIMUM {
+            vec![Length::MEDIUM_LENGTH_TOKEN, length as u8]
+        } else {
+            vec![
+                Length::LONG_LENGTH_TOKEN,
+                (length >> 8) as u8,
+                (length & 0xff) as u8,
+            ]
+        }
+    }
+
+    pub fn value(&self) -> u16 {
+        self.length
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+}
+
+impl Encode for Length {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: std::io::prelude::Write,
+    {
+        let bytes: Vec<u8> = self.to_vec();
+        writer.write_all(&bytes)
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        let bytes: Vec<u8> = self.to_vec();
+        Ok(Length::new(bytes.len() as u16))
+    }
+}
+
+impl std::ops::Add for Length {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self::new(self.length + other.length)
+    }
+}
+
+impl std::ops::AddAssign for Length {
+    fn add_assign(&mut self, other: Self) {
+        self.length += other.length;
+    }
+}

--- a/libs/tlv/src/lib.rs
+++ b/libs/tlv/src/lib.rs
@@ -1,0 +1,354 @@
+pub mod coder;
+pub mod length;
+pub mod tag;
+pub mod value;
+
+pub use coder::{Decode, Encode};
+pub use length::Length;
+pub use tag::Tag;
+
+/// Encodes a value into a vector.
+///
+/// # Errors
+///
+/// Returns an error if the value cannot be encoded.
+///
+/// # Panics
+///
+/// Panics if the encoded length does not match the expected length of the
+/// value.
+///
+/// # Examples
+///
+/// ```
+/// # use tlv::{Encode, to_vec};
+/// #
+/// # fn main() -> std::io::Result<()> {
+/// let value: u16 = 0xbeef;
+/// let encoded = to_vec(value)?;
+/// assert_eq!(encoded, [0xbe, 0xef]);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Most of the time you'll want to use this with a struct from `tlv-derive`.
+pub fn to_vec<E>(value: E) -> std::io::Result<Vec<u8>>
+where
+    E: Encode,
+{
+    let mut buffer = Vec::new();
+    value.encode(&mut buffer)?;
+    assert_eq!(buffer.len(), value.encoded_length()?.value() as usize);
+    Ok(buffer)
+}
+
+/// Encodes a tagged value into a vector.
+///
+/// # Errors
+///
+/// Returns an error if the value cannot be encoded.
+///
+/// # Panics
+///
+/// Panics if the encoded length does not match the expected length of the
+/// value.
+///
+/// # Examples
+///
+/// ```
+/// # use tlv::{Encode, Tag, to_vec_tagged};
+/// #
+/// # fn main() -> std::io::Result<()> {
+/// let value: u16 = 0xbeef;
+/// let encoded = to_vec_tagged(Tag::U8(0xff), value)?;
+/// assert_eq!(encoded, [0xff, 0x02, 0xbe, 0xef]);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Most of the time you'll want to use this with a struct from `tlv-derive`.
+pub fn to_vec_tagged<E>(tag: Tag, value: E) -> std::io::Result<Vec<u8>>
+where
+    E: Encode,
+{
+    let mut buffer = Vec::new();
+    value::encode_tagged(tag, value, &mut buffer)?;
+    Ok(buffer)
+}
+
+/// Decodes a value from a slice.
+///
+/// # Errors
+///
+/// Returns an error if the value cannot be decoded.
+///
+/// # Examples
+///
+/// ```
+/// # use tlv::{Decode, from_slice};
+/// #
+/// # fn main() -> std::io::Result<()> {
+/// let buffer = [0xbe, 0xef];
+/// let value: u16 = from_slice(&buffer)?;
+/// assert_eq!(value, 0xbeef);
+/// # Ok(())
+/// # }
+/// ```
+pub fn from_slice<D>(buffer: &[u8]) -> std::io::Result<D>
+where
+    D: Decode,
+{
+    let mut cursor = std::io::Cursor::new(buffer);
+    let (value, read) = D::decode(&mut cursor)?;
+
+    if read != buffer.len() {
+        Err(std::io::ErrorKind::InvalidData.into())
+    } else {
+        Ok(value)
+    }
+}
+
+/// Decodes a tagged value from a slice.
+///
+/// # Errors
+///
+/// Returns an error if the value cannot be decoded.
+///
+/// # Examples
+///
+/// ```
+/// # use tlv::{Decode, from_slice_tagged, Tag};
+/// #
+/// # fn main() -> std::io::Result<()> {
+/// let buffer = [0xff, 0x02, 0xbe, 0xef];
+/// let value: u16 = from_slice_tagged(Tag::U8(0xff), &buffer)?;
+/// assert_eq!(value, 0xbeef);
+/// # Ok(())
+/// # }
+/// ```
+pub fn from_slice_tagged<D>(tag: Tag, buffer: &[u8]) -> std::io::Result<D>
+where
+    D: Decode,
+{
+    let mut cursor = std::io::Cursor::new(buffer);
+    let (value, read) = value::decode_tagged(tag, &mut cursor)?;
+
+    if read != buffer.len() {
+        Err(std::io::ErrorKind::InvalidData.into())
+    } else {
+        Ok(value)
+    }
+}
+
+/// Decodes a tagged value from a reader, returning the value and the number of
+/// bytes read.
+///
+/// # Errors
+///
+/// Returns an error if the value cannot be decoded.
+///
+/// # Examples
+///
+/// ```
+/// # use tlv::{Decode, from_reader_tagged, Tag};
+/// #
+/// # fn main() -> std::io::Result<()> {
+/// let buffer = [0xff, 0x02, 0xbe, 0xef];
+/// let mut cursor = std::io::Cursor::new(&buffer);
+/// let (value, read) = from_reader_tagged::<u16, _>(Tag::U8(0xff), &mut cursor)?;
+/// assert_eq!(value, 0xbeef);
+/// assert_eq!(read, buffer.len());
+/// # Ok(())
+/// # }
+/// ```
+pub fn from_reader_tagged<D, R>(tag: Tag, reader: &mut R) -> std::io::Result<(D, usize)>
+where
+    D: Decode,
+    R: std::io::Read,
+{
+    value::decode_tagged(tag, reader)
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::proptest;
+
+    use crate::{
+        from_reader_tagged, from_slice, from_slice_tagged, tag::Tag, to_vec, to_vec_tagged, Decode,
+        Encode, Length,
+    };
+
+    #[test]
+    fn test_full_tlv_tag_mismatch() {
+        let value: u16 = 0xbeef;
+        let encoded = to_vec_tagged(Tag::U16(0x0102), &value).unwrap();
+
+        from_slice_tagged::<Vec<u8>>(Tag::U16(0x0103), &encoded).unwrap_err();
+    }
+
+    #[test]
+    fn test_multiple_decode() {
+        let data: [u8; 9] = [0x01, 0x02, 0xbe, 0xef, 0x99, 0x00, 0xff, 0x01, 0xfe];
+        let mut cursor = std::io::Cursor::new(&data);
+
+        let (beef, read) = from_reader_tagged::<u16, _>(Tag::U8(0x01), &mut cursor).unwrap();
+        assert_eq!(beef, 0xbeef);
+        assert_eq!(read, 4);
+
+        let (_, read) = from_reader_tagged::<(), _>(Tag::U8(0x99), &mut cursor).unwrap();
+        assert_eq!(read, 2);
+
+        let (fe, read) = from_reader_tagged::<u8, _>(Tag::U8(0xff), &mut cursor).unwrap();
+        assert_eq!(fe, 0xfe);
+        assert_eq!(read, 3);
+
+        assert_eq!(cursor.position(), data.len() as u64);
+    }
+
+    #[test]
+    fn test_encode_codegen() {
+        struct Test {
+            a: u8,
+            b: u16,
+        }
+
+        // This is implemented in a way that is conducive to code generation.
+        impl Encode for Test {
+            fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+                crate::value::encode_tagged(Tag::U8(0x01), &self.a, writer)?;
+                crate::value::encode_tagged(Tag::U8(0x02), &self.b, writer)?;
+                Ok(())
+            }
+
+            fn encoded_length(&self) -> std::io::Result<crate::Length> {
+                let mut length = Length::new(0);
+                length += crate::value::length_tagged(Tag::U8(0x01), &self.a)?;
+                length += crate::value::length_tagged(Tag::U8(0x01), &self.b)?;
+                Ok(length)
+            }
+        }
+
+        let value = Test { a: 0x99, b: 0xabcd };
+        let encoded = [0x01, 0x01, 0x99, 0x02, 0x02, 0xab, 0xcd];
+
+        assert_eq!(to_vec(&value).unwrap(), encoded);
+        assert_eq!(value.encoded_length().unwrap(), Length::new(7));
+    }
+
+    #[test]
+    fn test_decode_codegen() {
+        struct Test {
+            a: u8,
+            b: u16,
+        }
+
+        // This is implemented in a way that is conducive to code generation.
+        impl Decode for Test {
+            fn decode<R: std::io::Read>(reader: &mut R) -> std::io::Result<(Self, usize)> {
+                let tlv_decode_read: usize = 0;
+                let (a, tlv_decode_read) = match crate::value::decode_tagged(Tag::U8(0x01), reader)?
+                {
+                    (a, read) => (a, tlv_decode_read + read),
+                };
+                let (b, tlv_decode_read) = match crate::value::decode_tagged(Tag::U8(0x02), reader)?
+                {
+                    (b, read) => (b, tlv_decode_read + read),
+                };
+                Ok((Test { a, b }, tlv_decode_read))
+            }
+        }
+
+        let data = vec![0x01, 0x01, 0x99, 0x02, 0x02, 0xab, 0xcd];
+        let decoded: Test = from_slice(&data).unwrap();
+        assert_eq!(decoded.a, 0x99);
+        assert_eq!(decoded.b, 0xabcd);
+    }
+
+    #[test]
+    fn test_medium_length() {
+        let tag = Tag::U8(0x01);
+        let value = vec![0xbe; 0x81];
+        let encoded = to_vec_tagged(tag, &value).unwrap();
+
+        //                        tag    MED   len   data …
+        assert_eq!(encoded[0..4], [0x01, 0x81, 0x81, 0xbe]);
+
+        let decoded: Vec<u8> = from_slice_tagged(tag, &encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_long_length() {
+        let tag = Tag::U8(0x01);
+        let value = vec![0xbe; 0x100];
+        let encoded = to_vec_tagged(tag, &value).unwrap();
+
+        //                        tag    LONG  len0  len1  data …
+        assert_eq!(encoded[0..5], [0x01, 0x82, 0x01, 0x00, 0xbe]);
+
+        let decoded: Vec<u8> = from_slice_tagged(tag, &encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_boolean() {
+        assert_eq!(to_vec(true).unwrap(), [0x01]);
+        assert_eq!(to_vec(false).unwrap(), [0x00]);
+    }
+
+    proptest! {
+        #[test]
+        fn test_encode_decode_u8(tag_byte: u8, value: u8) {
+            let tag = Tag::U8(tag_byte);
+            let encoded = to_vec_tagged(tag, &value).unwrap();
+
+            let decoded_value: u8 = from_slice_tagged(tag, &encoded).unwrap();
+            assert_eq!(decoded_value, value);
+        }
+
+        #[test]
+        fn test_encode_decode_u16(tag_byte: u8, value: u16) {
+            let tag = Tag::U8(tag_byte);
+            let encoded = to_vec_tagged(tag, &value).unwrap();
+
+            let decoded_value: u16 = from_slice_tagged(tag, &encoded).unwrap();
+            assert_eq!(decoded_value, value);
+        }
+
+        #[test]
+        fn test_encode_decode_u32(tag_byte: u8, value: u32) {
+            let tag = Tag::U8(tag_byte);
+            let encoded = to_vec_tagged(tag, &value).unwrap();
+
+            let decoded_value: u32 = from_slice_tagged(tag, &encoded).unwrap();
+            assert_eq!(decoded_value, value);
+        }
+
+        #[test]
+        fn test_encode_decode_u64(tag_byte: u8, value: u64) {
+            let tag = Tag::U8(tag_byte);
+            let encoded = to_vec_tagged(tag, &value).unwrap();
+
+            let decoded_value: u64 = from_slice_tagged(tag, &encoded).unwrap();
+            assert_eq!(decoded_value, value);
+        }
+
+        #[test]
+        fn test_encode_decode_buffer(tag_byte: u8, value: Vec<u8>) {
+            let tag = Tag::U8(tag_byte);
+            let encoded = to_vec_tagged(tag, &value).unwrap();
+
+            let decoded_value: Vec<u8> = from_slice_tagged(tag, &encoded).unwrap();
+            assert_eq!(decoded_value, value);
+        }
+
+        #[test]
+        fn test_encode_decode_string(tag_byte: u8, value: String) {
+            let tag = Tag::U8(tag_byte);
+            let encoded = to_vec_tagged(tag, &value).unwrap();
+
+            let decoded_value: String = from_slice_tagged(tag, &encoded).unwrap();
+            assert_eq!(decoded_value, value);
+        }
+    }
+}

--- a/libs/tlv/src/limited_reader.rs
+++ b/libs/tlv/src/limited_reader.rs
@@ -1,0 +1,93 @@
+use std::io::Read;
+
+/// A reader that limits the number of bytes that can be read. This is used to
+/// prevent reading more bytes than expected from a stream, such as when reading
+/// a variable-length value like a [`String`].
+pub(crate) struct LimitedReader<R: Read> {
+    reader: R,
+    remaining_bytes: usize,
+}
+
+impl<R: Read> LimitedReader<R> {
+    pub(crate) const fn new(reader: R, max_bytes: usize) -> Self {
+        Self {
+            reader,
+            remaining_bytes: max_bytes,
+        }
+    }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.remaining_bytes == 0 {
+            return Ok(0);
+        }
+
+        let buf_len = buf.len();
+        let buf = &mut buf[..usize::min(buf_len, self.remaining_bytes)];
+        let read = self.reader.read(buf)?;
+        self.remaining_bytes -= read;
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::proptest;
+
+    use super::*;
+
+    #[test]
+    fn read_all_bytes() {
+        let data = [1, 2, 3, 4, 5];
+        let mut reader = LimitedReader::new(&data[..], data.len());
+        let mut buf = [0; 5];
+        let read = reader.read(&mut buf).unwrap();
+        assert_eq!(read, 5);
+        assert_eq!(&buf, &data);
+    }
+
+    #[test]
+    fn read_unlimited_bytes() {
+        let data = [1, 2, 3, 4, 5];
+        let mut reader = LimitedReader::new(&data[..], usize::MAX);
+        let mut buf = [0; 5];
+        let read = reader.read(&mut buf).unwrap();
+        assert_eq!(read, 5);
+        assert_eq!(&buf, &data);
+    }
+
+    #[test]
+    fn read_some_bytes() {
+        let data = [1, 2, 3, 4, 5];
+        let mut reader = LimitedReader::new(&data[..], 3);
+        let mut buf = [0; 5];
+        let read = reader.read(&mut buf).unwrap();
+        assert_eq!(read, 3);
+        assert_eq!(&buf[..3], &data[..3]);
+        assert_eq!(&buf[3..], &[0, 0]);
+    }
+
+    #[test]
+    fn read_no_bytes() {
+        let data = [1, 2, 3, 4, 5];
+        let mut reader = LimitedReader::new(&data[..], 0);
+        let mut buf = [0; 5];
+        let read = reader.read(&mut buf).unwrap();
+        assert_eq!(read, 0);
+        assert_eq!(&buf, &[0, 0, 0, 0, 0]);
+    }
+
+    proptest! {
+        #[test]
+        fn read_bytes(bytes: Vec<u8>, max_bytes: usize) {
+            let mut reader = LimitedReader::new(&bytes[..], max_bytes);
+            let mut buf = vec![0; bytes.len()];
+            let read = reader.read(&mut buf).unwrap();
+            let expected = usize::min(max_bytes, bytes.len());
+            assert_eq!(read, expected);
+            assert_eq!(&buf[..read], &bytes[..read]);
+            buf[read..].iter().for_each(|&b| assert_eq!(b, 0));
+        }
+    }
+}

--- a/libs/tlv/src/tag.rs
+++ b/libs/tlv/src/tag.rs
@@ -11,14 +11,6 @@ pub enum Tag {
 }
 
 impl Tag {
-    /// Returns the length of the tag in bytes.
-    pub const fn len(&self) -> usize {
-        match self {
-            Self::U8(_) => std::mem::size_of::<u8>(),
-            Self::U16(_) => std::mem::size_of::<u16>(),
-        }
-    }
-
     /// Converts the tag into a byte representation.
     pub fn to_vec(&self) -> Vec<u8> {
         match self {
@@ -37,7 +29,10 @@ impl Encode for Tag {
     }
 
     fn encoded_length(&self) -> std::io::Result<Length> {
-        Ok(Length::new(self.len() as u16))
+        Ok(Length::new(match self {
+            Self::U8(_) => std::mem::size_of::<u8>(),
+            Self::U16(_) => std::mem::size_of::<u16>(),
+        } as u16))
     }
 }
 

--- a/libs/tlv/src/tag.rs
+++ b/libs/tlv/src/tag.rs
@@ -1,0 +1,55 @@
+use crate::{Encode, Length};
+
+/// A tag for TLV encoding.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Tag {
+    /// A tag with a single byte.
+    U8(u8),
+
+    /// A tag with two bytes.
+    U16(u16),
+}
+
+impl Tag {
+    /// Returns the length of the tag in bytes.
+    pub const fn len(&self) -> usize {
+        match self {
+            Self::U8(_) => std::mem::size_of::<u8>(),
+            Self::U16(_) => std::mem::size_of::<u16>(),
+        }
+    }
+
+    /// Converts the tag into a byte representation.
+    pub fn to_vec(&self) -> Vec<u8> {
+        match self {
+            Self::U8(value) => vec![*value],
+            Self::U16(value) => value.to_be_bytes().to_vec(),
+        }
+    }
+}
+
+impl Encode for Tag {
+    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: std::io::Write,
+    {
+        writer.write_all(&self.to_vec())
+    }
+
+    fn encoded_length(&self) -> std::io::Result<Length> {
+        Ok(Length::new(self.len() as u16))
+    }
+}
+
+impl PartialEq<[u8]> for Tag {
+    fn eq(&self, other: &[u8]) -> bool {
+        match (self, other) {
+            (Tag::U8(byte), [other_byte]) => byte == other_byte,
+            (Tag::U16(value), [other_byte0, other_byte1]) => {
+                let other_value = u16::from_be_bytes([*other_byte0, *other_byte1]);
+                value == &other_value
+            }
+            _ => false,
+        }
+    }
+}

--- a/libs/tlv/src/tag.rs
+++ b/libs/tlv/src/tag.rs
@@ -1,4 +1,4 @@
-use crate::{Encode, Length};
+use crate::{Encode, Length, Result};
 
 /// A tag for TLV encoding.
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -21,14 +21,14 @@ impl Tag {
 }
 
 impl Encode for Tag {
-    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
+    fn encode<W>(&self, writer: &mut W) -> Result<()>
     where
         W: std::io::Write,
     {
-        writer.write_all(&self.to_vec())
+        Ok(writer.write_all(&self.to_vec())?)
     }
 
-    fn encoded_length(&self) -> std::io::Result<Length> {
+    fn encoded_length(&self) -> Result<Length> {
         Ok(Length::new(match self {
             Self::U8(_) => std::mem::size_of::<u8>(),
             Self::U16(_) => std::mem::size_of::<u16>(),

--- a/libs/tlv/src/value.rs
+++ b/libs/tlv/src/value.rs
@@ -1,7 +1,7 @@
-use crate::{Decode, Encode, Length, Tag};
+use crate::{limited_reader::LimitedReader, Decode, Encode, Error, Length, Result, Tag};
 
 /// Encodes a full TLV value into a writer.
-pub fn encode_tagged<E, W>(tag: Tag, value: E, writer: &mut W) -> std::io::Result<()>
+pub fn encode_tagged<E, W>(tag: Tag, value: E, writer: &mut W) -> Result<()>
 where
     E: Encode,
     W: std::io::Write,
@@ -13,7 +13,7 @@ where
 }
 
 /// Computes the full TLV length for a tagged value.
-pub fn length_tagged<E>(tag: Tag, value: E) -> std::io::Result<Length>
+pub fn length_tagged<E>(tag: Tag, value: E) -> Result<Length>
 where
     E: Encode,
 {
@@ -21,7 +21,7 @@ where
     Ok(tag.encoded_length()? + length.encoded_length()? + length)
 }
 
-pub fn decode_tagged<D, R>(tag: Tag, reader: &mut R) -> std::io::Result<(D, usize)>
+pub fn decode_tagged<D, R>(tag: Tag, reader: &mut R) -> Result<(D, usize)>
 where
     D: Decode,
     R: std::io::Read,
@@ -34,14 +34,20 @@ where
     };
 
     if tag_bytes != read_tag_bytes {
-        return Err(std::io::ErrorKind::InvalidData.into());
+        return Err(Error::InvalidTag {
+            expected: tag_bytes,
+            actual: read_tag_bytes,
+        });
     }
 
     let length = Length::from_reader(reader)?;
-    let (value, value_size) = D::decode(reader)?;
+    let (value, value_size) = D::decode(&mut LimitedReader::new(reader, length.value().into()))?;
 
-    if value_size != length.value() as usize {
-        return Err(std::io::ErrorKind::InvalidData.into());
+    let expected = usize::from(length.value());
+    let actual = value_size;
+
+    if actual != expected {
+        return Err(Error::InvalidLength { expected, actual });
     }
 
     Ok((

--- a/libs/tlv/src/value.rs
+++ b/libs/tlv/src/value.rs
@@ -13,7 +13,7 @@ where
 }
 
 /// Computes the full TLV length for a tagged value.
-pub fn length_tagged<E>(tag: Tag, value: &E) -> std::io::Result<Length>
+pub fn length_tagged<E>(tag: Tag, value: E) -> std::io::Result<Length>
 where
     E: Encode,
 {

--- a/libs/tlv/src/value.rs
+++ b/libs/tlv/src/value.rs
@@ -1,0 +1,51 @@
+use crate::{Decode, Encode, Length, Tag};
+
+/// Encodes a full TLV value into a writer.
+pub fn encode_tagged<E, W>(tag: Tag, value: E, writer: &mut W) -> std::io::Result<()>
+where
+    E: Encode,
+    W: std::io::Write,
+{
+    tag.encode(writer)?;
+    let length = value.encoded_length()?;
+    length.encode(writer)?;
+    value.encode(writer)
+}
+
+/// Computes the full TLV length for a tagged value.
+pub fn length_tagged<E>(tag: Tag, value: &E) -> std::io::Result<Length>
+where
+    E: Encode,
+{
+    let length = value.encoded_length()?;
+    Ok(tag.encoded_length()? + length.encoded_length()? + length)
+}
+
+pub fn decode_tagged<D, R>(tag: Tag, reader: &mut R) -> std::io::Result<(D, usize)>
+where
+    D: Decode,
+    R: std::io::Read,
+{
+    let tag_bytes = tag.to_vec();
+    let read_tag_bytes = {
+        let mut buf = vec![0; tag_bytes.len()];
+        reader.read_exact(&mut buf)?;
+        buf
+    };
+
+    if tag_bytes != read_tag_bytes {
+        return Err(std::io::ErrorKind::InvalidData.into());
+    }
+
+    let length = Length::from_reader(reader)?;
+    let (value, value_size) = D::decode(reader)?;
+
+    if value_size != length.value() as usize {
+        return Err(std::io::ErrorKind::InvalidData.into());
+    }
+
+    Ok((
+        value,
+        tag_bytes.len() + length.encoded_length()?.value() as usize + value_size,
+    ))
+}


### PR DESCRIPTION
## Overview

These libraries provide TLV encode/decode functionality.

## Demo Video or Screenshot

An example of `derive`ing `tlv::Decode` and `tlv::Encode` and basic usage:
```rust
#[derive(tlv::Decode, tlv::Encode)]
struct Test {
    #[tlv(tag = 0x20)]
    a: u8,
    #[tlv(tag = 0x21)]
    b: u16,
}

let value = Test { a: 0, b: 999 };
let encoded = tlv::to_vec(&value)?;
let decoded: Test = tlv::from_slice(&encoded)?;
```

This is what the derive macros actually expand to (courtesy of `cargo expand`):

```rust
use tlv::Encode;
use tlv_derive::{Decode, Encode};
struct Test {
    #[tlv(tag = 0x20)]
    a: u8,
    #[tlv(tag = 0x21)]
    b: u16,
}
impl tlv::Encode for Test {
    fn encode<W>(&self, writer: &mut W) -> std::io::Result<()>
    where
        W: std::io::Write,
    {
        tlv::value::encode_tagged(tlv::Tag::U8(32u8), &self.a, writer)?;
        tlv::value::encode_tagged(tlv::Tag::U8(33u8), &self.b, writer)?;
        Ok(())
    }
    fn encoded_length(&self) -> std::io::Result<tlv::Length> {
        let mut length = tlv::Length::new(0);
        length += tlv::value::length_tagged(tlv::Tag::U8(32u8), &self.a)?;
        length += tlv::value::length_tagged(tlv::Tag::U8(33u8), &self.b)?;
        Ok(length)
    }
}
impl tlv::Decode for Test {
    fn decode<R>(reader: &mut R) -> std::io::Result<(Self, usize)>
    where
        R: std::io::Read,
    {
        let __tlv_decode_read: usize = 0;
        let (a, __tlv_decode_read) = match tlv::value::decode_tagged(
            tlv::Tag::U8(32u8),
            reader,
        )? {
            (value, read) => (value, read + __tlv_decode_read),
        };
        let (b, __tlv_decode_read) = match tlv::value::decode_tagged(
            tlv::Tag::U8(33u8),
            reader,
        )? {
            (value, read) => (value, read + __tlv_decode_read),
        };
        Ok((Self { a, b }, __tlv_decode_read))
    }
}
```

## Testing Plan
Adds a bunch of automated tests.