### PR TITLE
feat(mark): allow configuring what to expire in the usability test

### DIFF
--- a/apps/cacvote-mark/backend/src/env.d.ts
+++ b/apps/cacvote-mark/backend/src/env.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
     readonly IS_INTEGRATION_TEST?: string;
     readonly USABILITY_TEST_ELECTION_PATH?: string;
     readonly USABILITY_TEST_EXPIRATION_MINUTES?: string;
+    readonly USABILITY_TEST_EXPIRATION_TYPE?: string;
     readonly BASE_PORT?: string;
     readonly PORT?: string;
     readonly VX_CODE_VERSION?: string;

--- a/apps/cacvote-mark/backend/src/globals.ts
+++ b/apps/cacvote-mark/backend/src/globals.ts
@@ -5,6 +5,7 @@ import * as dotenvExpand from 'dotenv-expand';
 import fs from 'fs';
 import { join } from 'path';
 import { z } from 'zod';
+import { AutomaticExpirationTypeSchema } from './cacvote-server/usability_test_client';
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 const dotEnvPath = '.env';
@@ -75,6 +76,14 @@ export const USABILITY_TEST_EXPIRATION_MINUTES =
   safeParseInt(process.env.USABILITY_TEST_EXPIRATION_MINUTES, {
     min: 1,
   }).ok() ?? 2;
+
+/**
+ * Which type of automatic expiration should we use for the usability test?
+ */
+export const USABILITY_TEST_AUTOMATIC_EXPIRATION_TYPE =
+  AutomaticExpirationTypeSchema.optional().parse(
+    process.env.USABILITY_TEST_EXPIRATION_TYPE
+  ) ?? 'castBallotOnly';
 
 /**
  * What is the name of the mailing label printer?

--- a/apps/cacvote-mark/backend/src/server.ts
+++ b/apps/cacvote-mark/backend/src/server.ts
@@ -120,6 +120,7 @@ export async function start({
         before: DateTime.now().minus({
           minutes: USABILITY_TEST_EXPIRATION_MINUTES,
         }),
+        expire: 'castBallotOnly',
       });
     }, 1000);
   } else {

--- a/mprocs-usability-test.yaml
+++ b/mprocs-usability-test.yaml
@@ -1,13 +1,15 @@
 procs:
   cacvote-mark:
     cwd: 'apps/cacvote-mark/frontend'
+    stop: SIGINT
     shell: |
       export USABILITY_TEST_ELECTION_PATH=${USABILITY_TEST_ELECTION_PATH:-$HOME/Desktop/election.json}
-      rm -rf ../backend/dev-workspace
+      # rm -rf ../backend/dev-workspace
       pnpm tsc --build && pnpm start
 
   kiosk-browser:
     cwd: '../kiosk-browser'
+    stop: SIGKILL
     shell: |
       echo "Waiting for CACVote Mark to start…"
       while ! nc -z localhost 3000; do sleep 1; done

--- a/mprocs-usability-test.yaml
+++ b/mprocs-usability-test.yaml
@@ -1,7 +1,6 @@
 procs:
   cacvote-mark:
     cwd: 'apps/cacvote-mark/frontend'
-    stop: SIGINT
     shell: |
       export USABILITY_TEST_ELECTION_PATH=${USABILITY_TEST_ELECTION_PATH:-$HOME/Desktop/election.json}
       # rm -rf ../backend/dev-workspace
@@ -9,7 +8,6 @@ procs:
 
   kiosk-browser:
     cwd: '../kiosk-browser'
-    stop: SIGKILL
     shell: |
       echo "Waiting for CACVote Mark to start…"
       while ! nc -z localhost 3000; do sleep 1; done


### PR DESCRIPTION
Sounds like they want to do the registration upfront and then only test the voting flow, so make the default expiration be `castBallotOnly`.

