### PR TITLE
fix(jx): make tallies work again

### DIFF
--- a/apps/cacvote-jx-terminal/backend/bin/decrypt-tally.rs
+++ b/apps/cacvote-jx-terminal/backend/bin/decrypt-tally.rs
@@ -69,7 +69,7 @@ async fn main() -> color_eyre::Result<()> {
     let encrypted_tally = tally::accumulate(
         &opts.electionguard_classpath,
         &election.electionguard_election_metadata_blob,
-        once(cast_ballot.electionguard_encrypted_ballot.as_bytes()),
+        once(cast_ballot.electionguard_encrypted_ballot.as_slice()),
     )?;
 
     let pool = PgPoolOptions::new()

--- a/apps/cacvote-jx-terminal/backend/src/app.rs
+++ b/apps/cacvote-jx-terminal/backend/src/app.rs
@@ -516,7 +516,7 @@ async fn generate_encrypted_election_tally(
         &election.electionguard_election_metadata_blob,
         cast_ballots
             .iter()
-            .map(|cast_ballot| cast_ballot.electionguard_encrypted_ballot.as_bytes()),
+            .map(|cast_ballot| cast_ballot.electionguard_encrypted_ballot.as_slice()),
     ) {
         Ok(encrypted_tally) => encrypted_tally,
         Err(e) => {
@@ -842,7 +842,7 @@ async fn mix_encrypted_ballots(
         &election.electionguard_election_metadata_blob,
         cast_ballots
             .iter()
-            .map(|cast_ballot| cast_ballot.electionguard_encrypted_ballot.as_bytes()),
+            .map(|cast_ballot| cast_ballot.electionguard_encrypted_ballot.as_slice()),
         phases,
     ) {
         Ok(shuffled_ballots) => shuffled_ballots,

--- a/libs/types-rs/src/cacvote/mod.rs
+++ b/libs/types-rs/src/cacvote/mod.rs
@@ -569,7 +569,9 @@ pub struct CastBallot {
     pub registration_request_object_id: Uuid,
     pub registration_object_id: Uuid,
     pub election_object_id: Uuid,
-    pub electionguard_encrypted_ballot: String,
+
+    #[serde(with = "Base64Standard")]
+    pub electionguard_encrypted_ballot: Vec<u8>,
 }
 
 impl CastBallot {


### PR DESCRIPTION
This was broken because we weren't properly handling the encrypted ballot data as a base64-encoded string. Without this, the tally would succeed but be wrong and the mixnet shuffle would fail.

