### PR TITLE
pathing has changed since moving server from services to apps structure

### DIFF
--- a/apps/cacvote-server/backend/Makefile
+++ b/apps/cacvote-server/backend/Makefile
@@ -11,7 +11,7 @@ build:
 dist: build
 	@echo "📦 Packaging application…"
 	@rm -rf dist && mkdir dist
-	@cp ../../target/release/cacvote-server dist/cacvote-server
+	@cp ../../../target/release/cacvote-server dist/cacvote-server
 	@echo "- \e[34;4mdist/cacvote-server\e[0m: application binary"
 
 run:


### PR DESCRIPTION
Simple pathing update due to restructuring that moved `cacvote-server` from the old `services` pattern to the `apps/backend|frontend` pattern.