### PR TITLE
Account for new CACvote machine types in libs/auth and libs/auth-rs

### DIFF
--- a/libs/auth-rs/src/vx_card.rs
+++ b/libs/auth-rs/src/vx_card.rs
@@ -93,7 +93,7 @@ impl VxCard {
             VX_CUSTOM_CERT_FIELD_COMPONENT,
         )?;
 
-        if !matches!(vx_admin_cert_authority_cert_component, Some(component) if component == "admin")
+        if !matches!(vx_admin_cert_authority_cert_component, Some(component) if component == "admin" || component == "cacvote-jx-terminal")
         {
             return Err(CardReaderError::CertificateValidation(
                 "vx_admin_cert_authority_cert was not a valid VxAdmin cert".to_owned(),

--- a/libs/auth/scripts/create_production_machine_cert_signing_request.ts
+++ b/libs/auth/scripts/create_production_machine_cert_signing_request.ts
@@ -6,7 +6,7 @@ import { getRequiredEnvVar } from '../src/env_vars';
 
 const machineType = getRequiredEnvVar('VX_MACHINE_TYPE');
 const jurisdiction =
-  machineType === 'admin'
+  machineType === 'admin' || machineType === 'cacvote-jx-terminal'
     ? getRequiredEnvVar('VX_MACHINE_JURISDICTION')
     : undefined;
 

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -57,6 +57,15 @@ interface VxScanCustomCertFields {
   component: 'scan';
 }
 
+interface CacvoteJxTerminalCustomCertFields {
+  component: 'cacvote-jx-terminal';
+  jurisdiction: string;
+}
+
+interface CacvoteMarkCustomCertFields {
+  component: 'cacvote-mark';
+}
+
 interface SystemAdministratorCardCustomCertFields {
   component: 'card';
   jurisdiction: string;
@@ -82,6 +91,8 @@ export type CustomCertFields =
   | VxCentralScanCustomCertFields
   | VxMarkCustomCertFields
   | VxMarkScanCustomCertFields
+  | CacvoteJxTerminalCustomCertFields
+  | CacvoteMarkCustomCertFields
   | VxScanCustomCertFields
   | CardCustomCertFields;
 
@@ -126,6 +137,17 @@ const VxScanCustomCertFieldsSchema: z.ZodSchema<VxScanCustomCertFields> =
     component: z.literal('scan'),
   });
 
+const CacvoteJxTerminalCustomCertFieldsSchema: z.ZodSchema<CacvoteJxTerminalCustomCertFields> =
+  z.object({
+    component: z.literal('cacvote-jx-terminal'),
+    jurisdiction: z.string(),
+  });
+
+const CacvoteMarkCustomCertFieldsSchema: z.ZodSchema<CacvoteMarkCustomCertFields> =
+  z.object({
+    component: z.literal('cacvote-mark'),
+  });
+
 const SystemAdministratorCardCustomCertFieldsSchema: z.ZodSchema<SystemAdministratorCardCustomCertFields> =
   z.object({
     component: z.literal('card'),
@@ -159,6 +181,8 @@ const CustomCertFieldsSchema: z.ZodSchema<CustomCertFields> = z.union([
   VxMarkCustomCertFieldsSchema,
   VxMarkScanCustomCertFieldsSchema,
   VxScanCustomCertFieldsSchema,
+  CacvoteJxTerminalCustomCertFieldsSchema,
+  CacvoteMarkCustomCertFieldsSchema,
   CardCustomCertFieldsSchema,
 ]);
 
@@ -329,8 +353,10 @@ export function constructMachineCertSubject(
   jurisdiction?: string
 ): string {
   assert(
-    (machineType === 'admin' && jurisdiction !== undefined) ||
-      (machineType !== 'admin' && jurisdiction === undefined)
+    (['admin', 'cacvote-jx-terminal'].includes(machineType) &&
+      jurisdiction !== undefined) ||
+      (!['admin', 'cacvote-jx-terminal'].includes(machineType) &&
+        jurisdiction === undefined)
   );
   const entries = [
     ...STANDARD_CERT_FIELDS,

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -43,8 +43,8 @@ export function getMachineCertPathAndPrivateKey(): {
 } {
   const machineType = getRequiredEnvVar('VX_MACHINE_TYPE');
   const machineCertFileName =
-    machineType === 'admin'
-      ? 'vx-admin-cert-authority-cert.pem'
+    machineType === 'admin' || machineType === 'cacvote-jx-terminal'
+      ? `vx-${machineType}-cert-authority-cert.pem`
       : `vx-${machineType}-cert.pem`;
   if (shouldUseProdCerts()) {
     const configRoot = getRequiredEnvVar('VX_CONFIG_ROOT');
@@ -90,7 +90,7 @@ export function constructJavaCardConfig(): JavaCardConfig {
   let cardProgrammingConfig:
     | JavaCardConfig['cardProgrammingConfig']
     | undefined;
-  if (machineType === 'admin') {
+  if (machineType === 'admin' || machineType === 'cacvote-jx-terminal') {
     const { certPath, privateKey } = getMachineCertPathAndPrivateKey();
     cardProgrammingConfig = {
       vxAdminCertAuthorityCertPath: certPath,

--- a/libs/auth/src/env.d.ts
+++ b/libs/auth/src/env.d.ts
@@ -7,6 +7,8 @@ declare namespace NodeJS {
       | 'central-scan'
       | 'mark'
       | 'mark-scan'
-      | 'scan';
+      | 'scan'
+      | 'cacvote-jx-terminal'
+      | 'cacvote-mark';
   }
 }

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -277,7 +277,11 @@ export class JavaCard implements Card {
     const vxAdminCertAuthorityCertDetails = await parseCert(
       await fs.readFile(vxAdminCertAuthorityCertPath)
     );
-    assert(vxAdminCertAuthorityCertDetails.component === 'admin');
+    assert(
+      vxAdminCertAuthorityCertDetails.component === 'admin' ||
+        /* istanbul ignore next */
+        vxAdminCertAuthorityCertDetails.component === 'cacvote-jx-terminal'
+    );
     assert(
       user.jurisdiction === vxAdminCertAuthorityCertDetails.jurisdiction,
       `User jurisdiction ${user.jurisdiction} does not match cert authority jurisdiction ${vxAdminCertAuthorityCertDetails.jurisdiction}`
@@ -439,7 +443,11 @@ export class JavaCard implements Card {
     const vxAdminCertAuthorityCertDetails = await parseCert(
       vxAdminCertAuthorityCert
     );
-    assert(vxAdminCertAuthorityCertDetails.component === 'admin');
+    assert(
+      vxAdminCertAuthorityCertDetails.component === 'admin' ||
+        /* istanbul ignore next */
+        vxAdminCertAuthorityCertDetails.component === 'cacvote-jx-terminal'
+    );
     await verifyFirstCertWasSignedBySecondCert(
       vxAdminCertAuthorityCert,
       this.vxCertAuthorityCertPath


### PR DESCRIPTION
This PR accounts for the new CACvote machine types in `libs/auth` and `libs/auth-rs`, specifically making it such that 1) sys admin card bootstrapping in the `cacvote-jx-terminal` machine configuration wizard will work and 2) cards generated via that process will be accepted by the `cacvote-jx-terminal`.

I don't have a great test environment ready to go and need to shift back to other threads but am happy to address any errors that arise in testing!