### PR TITLE
using apt buildpack to install libpcsclite

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+libpcsclite1
+libpcsclite-dev


### PR DESCRIPTION
Just a quick test of using the apt buildpack to install libpcsclite packages. 