### PR TITLE
test disabling SQLX_OFFLINE

### DIFF
--- a/apps/cacvote-server/backend/script/build
+++ b/apps/cacvote-server/backend/script/build
@@ -5,4 +5,4 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "${DIR}/.."
 
-SQLX_OFFLINE=true cargo build
+SQLX_OFFLINE=false cargo build


### PR DESCRIPTION
Disabling SQLX_OFFLINE to test the heroku build. Even if this succeeds, it may not be the optimal solution for all other builds.