### PR TITLE
feat(jx): use `kiosk` open/save dialogs for file IO

### DIFF
--- a/apps/cacvote-jx-terminal/frontend/package.json
+++ b/apps/cacvote-jx-terminal/frontend/package.json
@@ -60,6 +60,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^29.5.3",
+    "@types/kiosk-browser": "workspace:*",
     "@types/luxon": "^3.0.0",
     "@types/react": "18.2.18",
     "@types/react-dom": "^18.2.7",

--- a/apps/cacvote-jx-terminal/frontend/src/components/create_election_modal.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/create_election_modal.tsx
@@ -52,6 +52,15 @@ export function CreateElectionModal({
 
   useModalKeybindings({ onEnter: onKeyboardEnter, onEscape: onClose });
 
+  const onElectionContentsLoaded = useCallback((electionJson: string) => {
+    setElectionDefinition(
+      safeParseElectionDefinition(electionJson).unsafeUnwrap()
+    );
+  }, []);
+
+  const chooseElectionButtonTitle =
+    electionDefinition?.election.title ?? 'Choose Election';
+
   return (
     <Modal
       title="Create New Election"
@@ -75,28 +84,43 @@ export function CreateElectionModal({
           <Label>
             Election Definition
             <br />
-            <FileInputButton
-              accept=".json"
-              onChange={(event) => {
-                const input = event.currentTarget;
-                const { files } = input;
-                /* istanbul ignore next */
-                const file = assertDefined(files?.[0]);
-                const reader = new FileReader();
-                reader.onload = () => {
-                  setElectionDefinition(
-                    safeParseElectionDefinition(
-                      reader.result as string
-                    ).unsafeUnwrap()
+            {window.kiosk ? (
+              <Button
+                onPress={async () => {
+                  assert(window.kiosk);
+                  const { canceled, filePaths } =
+                    await window.kiosk.showOpenDialog();
+
+                  if (canceled || filePaths.length === 0) {
+                    return;
+                  }
+
+                  const filePath = assertDefined(filePaths[0]);
+                  onElectionContentsLoaded(
+                    await window.kiosk.readFile(filePath, 'utf8')
                   );
-                };
-                reader.readAsText(file);
-              }}
-            >
-              {electionDefinition
-                ? electionDefinition.election.title
-                : 'Choose Election'}
-            </FileInputButton>
+                }}
+              >
+                {chooseElectionButtonTitle}
+              </Button>
+            ) : (
+              <FileInputButton
+                accept=".json"
+                onChange={(event) => {
+                  const input = event.currentTarget;
+                  const { files } = input;
+                  /* istanbul ignore next */
+                  const file = assertDefined(files?.[0]);
+                  const reader = new FileReader();
+                  reader.onload = () => {
+                    onElectionContentsLoaded(reader.result as string);
+                  };
+                  reader.readAsText(file);
+                }}
+              >
+                {chooseElectionButtonTitle}
+              </FileInputButton>
+            )}
           </Label>
         </React.Fragment>
       }

--- a/apps/cacvote-jx-terminal/frontend/src/components/create_election_modal.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/create_election_modal.tsx
@@ -89,7 +89,11 @@ export function CreateElectionModal({
                 onPress={async () => {
                   assert(window.kiosk);
                   const { canceled, filePaths } =
-                    await window.kiosk.showOpenDialog();
+                    await window.kiosk.showOpenDialog({
+                      filters: [
+                        { name: 'Election Definitions', extensions: ['json'] },
+                      ],
+                    });
 
                   if (canceled || filePaths.length === 0) {
                     return;

--- a/apps/cacvote-jx-terminal/frontend/src/screens/tally_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/tally_screen.tsx
@@ -91,10 +91,10 @@ export function TallyScreen(): JSX.Element | null {
     await generateEncryptedElectionTallyMutation.mutateAsync({ electionId });
   }
 
-  function onSaveEncryptedTallyPressed() {
+  async function onSaveEncryptedTallyPressed() {
     const encryptedTally = electionPresenter.getEncryptedTally();
     assert(encryptedTally);
-    downloadData(
+    await downloadData(
       encryptedTally
         .getEncryptedElectionTally()
         .getElectionguardEncryptedTally(),
@@ -106,10 +106,10 @@ export function TallyScreen(): JSX.Element | null {
     decryptEncryptedElectionTallyMutation.mutate({ electionId });
   }
 
-  function onSaveDecryptedTallyPressed() {
+  async function onSaveDecryptedTallyPressed() {
     const decryptedTally = electionPresenter.getDecryptedTally();
     assert(decryptedTally);
-    downloadData(
+    await downloadData(
       decryptedTally
         .getDecryptedElectionTally()
         .getElectionguardDecryptedTally(),

--- a/apps/cacvote-jx-terminal/frontend/src/utils/download.ts
+++ b/apps/cacvote-jx-terminal/frontend/src/utils/download.ts
@@ -1,8 +1,23 @@
-export function downloadData(data: Uint8Array, fileName: string): void {
-  const blob = new Blob([data], { type: 'application/octet-stream' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = fileName;
-  a.click();
+export async function downloadData(
+  data: Uint8Array,
+  fileName: string
+): Promise<void> {
+  if (window.kiosk) {
+    const { canceled, filePath } = await window.kiosk.showSaveDialog({
+      defaultPath: fileName,
+    });
+
+    if (canceled || !filePath) {
+      return;
+    }
+
+    await window.kiosk.writeFile(filePath, data);
+  } else {
+    const blob = new Blob([data], { type: 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+  }
 }

--- a/mprocs-cacvote-jx-terminal.yaml
+++ b/mprocs-cacvote-jx-terminal.yaml
@@ -11,7 +11,7 @@ procs:
       echo "- Run the 'reset-db' process below to reset the database."
       echo "- To exit mprocs, type 'q' to quit and then 'y' to confirm."
       echo ""
-      echo "The application is running at http://localhost:5000/."
+      echo "The application will launch in 'kiosk-browser' when it's ready."
       sleep 30d
 
   cacvote-jx-backend:
@@ -29,6 +29,16 @@ procs:
     shell: |
       export EG_CLASSPATH=${EG_CLASSPATH:-../../../../egk-ec-mixnet/build/libs/egk-ec-mixnet-2.1-SNAPSHOT-uber.jar}
       cargo watch -- cargo run
+
+  kiosk-browser:
+    cwd: '../kiosk-browser'
+    shell: |
+      echo "Waiting for CACvote JX Terminal to start…"
+      while ! nc -z localhost 5000; do sleep 1; done
+      kiosk-browser \
+        --allow-devtools \
+        -v 'o=http://localhost:*,p=**/*,rw' \
+        http://localhost:5000/
 
   reset-db:
     cwd: 'apps/cacvote-mark/backend'

--- a/mprocs-cacvote-mark.yaml
+++ b/mprocs-cacvote-mark.yaml
@@ -30,7 +30,7 @@ procs:
     shell: |
       echo "Waiting for CACvote Mark to start…"
       while ! nc -z localhost 3000; do sleep 1; done
-      kiosk-browser http://localhost:3000/
+      kiosk-browser --allow-devtools http://localhost:3000/
 
   reset-db:
     cwd: 'apps/cacvote-mark/backend'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.3
+      '@types/kiosk-browser':
+        specifier: workspace:*
+        version: link:../../../libs/@types/kiosk-browser
       '@types/luxon':
         specifier: ^3.0.0
         version: 3.2.0
@@ -10658,7 +10661,6 @@ packages:
 
   /chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
-    deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
     dependencies:
       anymatch: 2.0.0
       async-each: 1.0.6
@@ -13269,7 +13271,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
When running in `kiosk-browser` we use its extensions to make interacting with the file system easier.
