### PR TITLE
feat(jx): download ballot manifest from election tally page

### DIFF
--- a/apps/cacvote-jx-terminal/frontend/src/api.ts
+++ b/apps/cacvote-jx-terminal/frontend/src/api.ts
@@ -236,3 +236,23 @@ export const authenticate = {
     });
   },
 } as const;
+
+/**
+ * Gets the raw mailing label data for the given election. We don't parse it
+ * here because we're just going to download it.
+ */
+export async function getScannedMailingLabelsRawByElection(
+  electionId: Uuid
+): Promise<Uint8Array> {
+  const response = await fetch(
+    `/api/elections/${electionId}/scanned-mailing-labels`
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch scanned mailing labels: ${response.statusText}`
+    );
+  }
+
+  const blob = await response.blob();
+  return new Uint8Array(await blob.arrayBuffer());
+}

--- a/apps/cacvote-jx-terminal/frontend/src/screens/tally_screen.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/screens/tally_screen.tsx
@@ -51,6 +51,9 @@ export function TallyScreen(): JSX.Element | null {
   const shuffleEncryptedBallotsMutation =
     api.shuffleEncryptedBallots.useMutation();
 
+  const [isDownloadingBallotManifest, setIsDownloadingBallotManifest] =
+    useState(false);
+
   if (!isAuthenticated || !electionId) {
     return null;
   }
@@ -243,6 +246,34 @@ export function TallyScreen(): JSX.Element | null {
             Shuffle Ballots
           </Button>
         )}
+      </P>
+      <H2>Ballot Manifest</H2>
+      <P>
+        Save the manifest of validated paper ballots received for this election.
+        The manifest contains the voter’s Common Access Card number and
+        encrypted ballot signature hash for each ballot cast.
+      </P>
+      <P>
+        <Button
+          icon="Export"
+          disabled={isDownloadingBallotManifest}
+          onPress={async () => {
+            setIsDownloadingBallotManifest(true);
+            try {
+              const ballotManifestData =
+                await api.getScannedMailingLabelsRawByElection(electionId);
+
+              await downloadData(
+                ballotManifestData,
+                `ballot-manifest-${electionId}.json`
+              );
+            } finally {
+              setIsDownloadingBallotManifest(false);
+            }
+          }}
+        >
+          Save Ballot Manifest
+        </Button>
       </P>
     </NavigationScreen>
   );

--- a/apps/cacvote-server/frontend/src/api.ts
+++ b/apps/cacvote-server/frontend/src/api.ts
@@ -10,7 +10,7 @@ export const postScannedCode = {
   useMutation() {
     return useMutation(
       async (data: Uint8Array): Promise<Result<{ id: string }, string>> => {
-        const response = await fetch('/api/scanned-mailing-label-code', {
+        const response = await fetch('/api/scanned-mailing-label', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/octet-stream',
@@ -37,7 +37,7 @@ export type SearchByCommonAccessCardIdResponse = SearchResult[];
 
 export type SearchResult =
   | CastBallotSearchResult
-  | ScannedMailingLabelCodeSearchResult;
+  | ScannedMailingLabelSearchResult;
 
 export interface CastBallotSearchResult {
   type: 'castBallot';
@@ -51,8 +51,8 @@ export interface CastBallotSearchResult {
   createdAt: string;
 }
 
-export interface ScannedMailingLabelCodeSearchResult {
-  type: 'scannedMailingLabelCode';
+export interface ScannedMailingLabelSearchResult {
+  type: 'scannedMailingLabel';
   machineId: string;
   commonAccessCardId: string;
   electionObjectId: string;

--- a/apps/cacvote-server/frontend/src/screens/search_screen.tsx
+++ b/apps/cacvote-server/frontend/src/screens/search_screen.tsx
@@ -79,7 +79,7 @@ export function SearchScreen(): JSX.Element {
                     <TD>
                       {result.type === 'castBallot'
                         ? '🗳️ Cast Ballot'
-                        : result.type === 'scannedMailingLabelCode'
+                        : result.type === 'scannedMailingLabel'
                         ? '📬 Captured Mail Label'
                         : throwIllegalValue(result)}
                     </TD>


### PR DESCRIPTION
Adds the `/api/elections/{election_id}/scanned-mailing-labels` endpoint to the JX terminal backend in order to proxy it to `cacvote-server`.