### PR TITLE
fix(jx): log out on card reader removal

### DIFF
--- a/apps/cacvote-jx-terminal/backend/src/session_manager.rs
+++ b/apps/cacvote-jx-terminal/backend/src/session_manager.rs
@@ -130,7 +130,7 @@ impl SessionManager {
                                             }
                                         }
                                     }
-                                    auth_rs::Event::CardRemoved { .. } => {
+                                    auth_rs::Event::CardRemoved { .. } | auth_rs::Event::ReaderRemoved { .. } => {
                                         // clear the card so we don't try to use it
                                         vx_card = None;
                                         session_data_tx.send_replace(cacvote::SessionData::Unauthenticated {
@@ -138,7 +138,7 @@ impl SessionManager {
                                         });
                                     }
                                     auth_rs::Event::ReaderAdded { .. }
-                                    | auth_rs::Event::ReaderRemoved { .. } => {
+                                     => {
                                         // ignore
                                     }
                                 },


### PR DESCRIPTION
Previously, you'd just stay logged in. I'd assumed that if the card reader was removed that we'd also get a `CardRemoved` event, because this is how it works when you plug the card reader in (you get both `ReaderAdded` and `CardInserted`). However, this is not the case. This change ensures that we log the user out when the reader is removed. At this time, we assume a single reader.