### PR TITLE
fix(jx): show error on invalid PIN

### DIFF
--- a/apps/cacvote-jx-terminal/frontend/src/api.ts
+++ b/apps/cacvote-jx-terminal/frontend/src/api.ts
@@ -230,9 +230,7 @@ export const authenticate = {
         body: JSON.stringify({ pin }),
       });
 
-      if (!response.ok) {
-        throw new Error(`Failed to authenticate: ${response.statusText}`);
-      }
+      return response.ok;
     });
   },
 } as const;

--- a/apps/cacvote-jx-terminal/frontend/src/app_root.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/app_root.tsx
@@ -21,6 +21,7 @@ export function AppRoot(): JSX.Element {
   const authenticateMutation = api.authenticate.useMutation();
   const sessionDataQuery = api.sessionData.useQuery();
   const sessionData = sessionDataQuery.data;
+  const authenticationFailed = authenticateMutation.data === false;
   const isUnauthenticated =
     sessionData && sessionData instanceof UnauthenticatedSessionData;
   const isAuthenticating =
@@ -32,9 +33,13 @@ export function AppRoot(): JSX.Element {
     }
   }, [isUnauthenticated, history]);
 
-  if (isAuthenticating && !authenticateMutation.isLoading) {
+  if (isAuthenticating) {
     return (
       <PinPadModal
+        isAuthenticating={authenticateMutation.isLoading}
+        error={
+          authenticationFailed ? 'Could not log in. Invalid PIN?' : undefined
+        }
         onEnter={(pin) => {
           authenticateMutation.mutate(pin);
         }}

--- a/apps/cacvote-jx-terminal/frontend/src/components/pin_pad_modal.tsx
+++ b/apps/cacvote-jx-terminal/frontend/src/components/pin_pad_modal.tsx
@@ -32,14 +32,14 @@ const EnteredCode = styled.div`
 export interface PinPadModalProps {
   onEnter: (pin: string) => void;
   title?: string;
-  disabled?: boolean;
+  isAuthenticating?: boolean;
   error?: string;
 }
 
 export function PinPadModal({
   onEnter,
   title = 'Enter Your PIN',
-  disabled,
+  isAuthenticating,
   error,
 }: PinPadModalProps): JSX.Element {
   const pinLength = PinLength.exactly(6);
@@ -48,6 +48,7 @@ export function PinPadModal({
   useEffect(() => {
     if (pinEntry.current.length === pinLength.max) {
       onEnter(pinEntry.current);
+      pinEntry.reset();
     }
   }, [onEnter, pinEntry, pinLength.max]);
 
@@ -61,7 +62,7 @@ export function PinPadModal({
           <EnteredCode>{pinEntry.display}</EnteredCode>
           <NumberPadWrapper>
             <NumberPad
-              disabled={disabled}
+              disabled={isAuthenticating}
               onButtonPress={pinEntry.handleDigit}
               onBackspace={pinEntry.handleBackspace}
               onClear={pinEntry.reset}


### PR DESCRIPTION
Currently, we're throwing an error which just causes the "Something Went Wrong" screen to appear. This changes that to show a (hardcoded) error instead. Also fixes the flicker that shows the "Insert Card Screen" while checking the PIN.
