### PR TITLE
build(mark): fix setup for the label printer

### DIFF
--- a/apps/cacvote-mark/backend/src/mail-label/nprint/client.ts
+++ b/apps/cacvote-mark/backend/src/mail-label/nprint/client.ts
@@ -55,7 +55,8 @@ export class Client {
       throw new Error('Failed to list printers');
     }
 
-    const printer = iter(response.printers)
+    const printer = await iter(response.printers)
+      .async()
       .filter(
         async ({ communicationType, devicePath }) =>
           communicationType === 'USB' && (await exists(devicePath))

--- a/apps/cacvote-mark/backend/src/mail-label/nprint/client.ts
+++ b/apps/cacvote-mark/backend/src/mail-label/nprint/client.ts
@@ -26,11 +26,16 @@ export class Client {
    *
    * @param bin The path to the `libNPrint` binary wrapper.
    * @param logger The logger to use for logging.
+   * @param printer The name of the printer to use.
    * @returns A promise that resolves to a `Client` instance once connected.
    */
-  static async connect(bin: string, logger: Logger): Promise<Client> {
+  static async connect(
+    bin: string,
+    logger: Logger,
+    printer: string
+  ): Promise<Client> {
     await logger.log(LogEventId.Info, 'system', {
-      message: `Connecting to nprint client via ${bin}`,
+      message: `Connecting to nprint printer ${printer} via ${bin}`,
     });
 
     const child = spawn(bin, { stdio: 'pipe' });
@@ -42,7 +47,7 @@ export class Client {
     });
 
     const client = new Client(new ChildProcessClient(child), logger);
-    await client.sendRequest({ request: 'connect' });
+    await client.sendRequest({ request: 'connect', printer });
     return client;
   }
 

--- a/apps/cacvote-mark/backend/src/mail-label/nprint/types.ts
+++ b/apps/cacvote-mark/backend/src/mail-label/nprint/types.ts
@@ -8,6 +8,7 @@ export const LengthSchema = z.union([
 export type Length = z.infer<typeof LengthSchema>;
 
 export const RequestSchema = z.union([
+  z.object({ request: z.literal('listPrinters') }),
   z.object({ request: z.literal('connect'), printer: z.string().min(1) }),
   z.object({ request: z.literal('disconnect') }),
   z.object({ request: z.literal('init') }),
@@ -26,12 +27,31 @@ export const IncomingMessageSchema = z.object({
 });
 export type IncomingMessage = z.infer<typeof IncomingMessageSchema>;
 
+export const CommunicationTypeSchema = z.union([
+  z.literal('USB'),
+  z.literal('Serial'),
+]);
+
+export type CommunicationType = z.infer<typeof CommunicationTypeSchema>;
+
+export const PrinterConfigurationSchema = z.object({
+  name: z.string().min(1),
+  communicationType: CommunicationTypeSchema,
+  devicePath: z.string().min(1),
+});
+
+export type PrinterConfiguration = z.infer<typeof PrinterConfigurationSchema>;
+
 export const ResponseSchema = z.discriminatedUnion('response', [
   z.object({ response: z.literal('ok') }),
   z.object({
     response: z.literal('error'),
     message: z.string().min(1),
     cause: z.unknown(),
+  }),
+  z.object({
+    response: z.literal('printers'),
+    printers: z.array(PrinterConfigurationSchema),
   }),
 ]);
 export type Response = z.infer<typeof ResponseSchema>;

--- a/apps/cacvote-mark/backend/src/mail-label/nprint/types.ts
+++ b/apps/cacvote-mark/backend/src/mail-label/nprint/types.ts
@@ -8,7 +8,7 @@ export const LengthSchema = z.union([
 export type Length = z.infer<typeof LengthSchema>;
 
 export const RequestSchema = z.union([
-  z.object({ request: z.literal('connect') }),
+  z.object({ request: z.literal('connect'), printer: z.string().min(1) }),
   z.object({ request: z.literal('disconnect') }),
   z.object({ request: z.literal('init') }),
   z.object({ request: z.literal('lineFeed') }),

--- a/apps/cacvote-mark/backend/src/mail-label/printing.ts
+++ b/apps/cacvote-mark/backend/src/mail-label/printing.ts
@@ -10,6 +10,12 @@ import { LIBNPRINT_WRAPPER_PATH } from '../globals';
 import { Workspace } from '../workspace';
 import { Client } from './nprint/client';
 
+/**
+ * This is the name `libNPrint` gives the default printer. In the future we may
+ * want to allow users to list available printers.
+ */
+export const DEFAULT_PRINTER_NAME = 'PRT001';
+
 export interface LabelPrinterInterface {
   printPdf(pdfData: Buffer): Promise<void>;
   close(): Promise<void>;
@@ -49,7 +55,11 @@ export class MockLabelPrinter implements LabelPrinterInterface {
 export async function getRealLabelPrinter(
   logger: Logger
 ): Promise<LabelPrinterInterface> {
-  const client = await Client.connect(LIBNPRINT_WRAPPER_PATH, logger);
+  const client = await Client.connect(
+    LIBNPRINT_WRAPPER_PATH,
+    logger,
+    DEFAULT_PRINTER_NAME
+  );
   return {
     printPdf: async (pdfData: Buffer) => {
       await client.printPdf(pdfData);

--- a/apps/cacvote-mark/backend/src/mail-label/printing.ts
+++ b/apps/cacvote-mark/backend/src/mail-label/printing.ts
@@ -10,12 +10,6 @@ import { LIBNPRINT_WRAPPER_PATH } from '../globals';
 import { Workspace } from '../workspace';
 import { Client } from './nprint/client';
 
-/**
- * This is the name `libNPrint` gives the default printer. In the future we may
- * want to allow users to list available printers.
- */
-export const DEFAULT_PRINTER_NAME = 'PRT001';
-
 export interface LabelPrinterInterface {
   printPdf(pdfData: Buffer): Promise<void>;
   close(): Promise<void>;
@@ -55,11 +49,7 @@ export class MockLabelPrinter implements LabelPrinterInterface {
 export async function getRealLabelPrinter(
   logger: Logger
 ): Promise<LabelPrinterInterface> {
-  const client = await Client.connect(
-    LIBNPRINT_WRAPPER_PATH,
-    logger,
-    DEFAULT_PRINTER_NAME
-  );
+  const client = await Client.connect(LIBNPRINT_WRAPPER_PATH, logger);
   return {
     printPdf: async (pdfData: Buffer) => {
       await client.printPdf(pdfData);

--- a/apps/cacvote-mark/backend/src/mail-label/rendering/index.tsx
+++ b/apps/cacvote-mark/backend/src/mail-label/rendering/index.tsx
@@ -1,8 +1,9 @@
 import { Buffer } from 'buffer';
+import { writeFile } from 'fs/promises';
 import { chromium } from 'playwright';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
-import { writeFile } from 'fs/promises';
+import { OPTIONAL_EXECUTABLE_PATH_OVERRIDE } from '../../chromium';
 import { QrCode } from './qrcode';
 
 export const SIZE_INCHES = {
@@ -206,6 +207,7 @@ async function renderToPdf(document: JSX.Element): Promise<Buffer> {
     // is on by default, but causes fonts to render more awkwardly at higher
     // resolutions, so we disable it
     args: ['--font-render-hinting=none'],
+    executablePath: OPTIONAL_EXECUTABLE_PATH_OVERRIDE,
   });
   const context = await browser.newContext();
   const page = await context.newPage();

--- a/apps/cacvote-mark/backend/src/mail-label/rendering/index.tsx
+++ b/apps/cacvote-mark/backend/src/mail-label/rendering/index.tsx
@@ -3,7 +3,6 @@ import { writeFile } from 'fs/promises';
 import { chromium } from 'playwright';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
-import { OPTIONAL_EXECUTABLE_PATH_OVERRIDE } from '../../chromium';
 import { QrCode } from './qrcode';
 
 export const SIZE_INCHES = {
@@ -207,7 +206,6 @@ async function renderToPdf(document: JSX.Element): Promise<Buffer> {
     // is on by default, but causes fonts to render more awkwardly at higher
     // resolutions, so we disable it
     args: ['--font-render-hinting=none'],
-    executablePath: OPTIONAL_EXECUTABLE_PATH_OVERRIDE,
   });
   const context = await browser.newContext();
   const page = await context.newPage();

--- a/apps/cacvote-mark/nprint/src/main.rs
+++ b/apps/cacvote-mark/nprint/src/main.rs
@@ -27,6 +27,7 @@ struct IncomingMessage {
     rename_all_fields = "camelCase"
 )]
 enum Request {
+    ListPrinters,
     Connect { printer: String },
     Disconnect,
     Init,
@@ -88,6 +89,9 @@ impl From<c_int> for Status {
 #[serde(tag = "response", rename_all = "camelCase")]
 enum Response {
     Ok,
+    Printers {
+        printers: Vec<String>,
+    },
     Error {
         message: String,
         cause: Option<nprint::Error>,
@@ -136,12 +140,30 @@ async fn main() -> anyhow::Result<()> {
                     serde_json::from_str(&line).context("Parsing incoming message")?;
 
                 let response = match request {
+                    Request::ListPrinters => {
+                        let printers = Printer::enumerate_printers()
+                            .await
+                            .context("Listing printers")?;
+                        Response::Printers { printers }
+                    }
                     Request::Connect { printer: name } => {
-                        let new_printer = Printer::open(name).await.context("Opening printer")?;
-                        event_rx = Some(new_printer.watch_events());
-                        printer = Some(new_printer);
+                        let printers = Printer::enumerate_printers()
+                            .await
+                            .context("Listing printers")?;
 
-                        Response::Ok
+                        if printers.into_iter().any(|p| p == name) {
+                            let new_printer =
+                                Printer::open(name).await.context("Opening printer")?;
+                            event_rx = Some(new_printer.watch_events());
+                            printer = Some(new_printer);
+
+                            Response::Ok
+                        } else {
+                            Response::Error {
+                                message: format!("Printer '{}' not found", name),
+                                cause: None,
+                            }
+                        }
                     }
                     Request::Disconnect => {
                         printer = None;

--- a/apps/cacvote-mark/nprint/src/main.rs
+++ b/apps/cacvote-mark/nprint/src/main.rs
@@ -5,7 +5,7 @@ use std::{future::pending, path::PathBuf, time::Duration};
 use anyhow::Context;
 use futures_lite::FutureExt;
 use libc::{c_int, c_uint};
-use nprint::{CallbackMessage, Error, Length, Printer};
+use nprint::{CallbackMessage, Error, Length, Printer, PrinterConfiguration};
 use serde::{Deserialize, Serialize};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -90,7 +90,7 @@ impl From<c_int> for Status {
 enum Response {
     Ok,
     Printers {
-        printers: Vec<String>,
+        printers: Vec<PrinterConfiguration>,
     },
     Error {
         message: String,
@@ -151,7 +151,7 @@ async fn main() -> anyhow::Result<()> {
                             .await
                             .context("Listing printers")?;
 
-                        if printers.into_iter().any(|p| p == name) {
+                        if printers.into_iter().any(|p| p.name == name) {
                             let new_printer =
                                 Printer::open(name).await.context("Opening printer")?;
                             event_rx = Some(new_printer.watch_events());
@@ -160,7 +160,7 @@ async fn main() -> anyhow::Result<()> {
                             Response::Ok
                         } else {
                             Response::Error {
-                                message: format!("Printer '{}' not found", name),
+                                message: format!("Printer '{name}' not found"),
                                 cause: None,
                             }
                         }

--- a/apps/cacvote-mark/nprint/src/nprint.rs
+++ b/apps/cacvote-mark/nprint/src/nprint.rs
@@ -450,6 +450,29 @@ pub struct Printer {
 }
 
 impl Printer {
+    pub async fn enumerate_printers() -> Result<Vec<String>, Error> {
+        const BUFFER_SIZE: usize = 1024;
+        let mut printers_buffer = [0u8; BUFFER_SIZE];
+
+        np!(NEnumPrinters(
+            printers_buffer.as_mut_ptr() as *mut c_char,
+            std::ptr::null_mut()
+        ));
+
+        let printers_str = unsafe {
+            CStr::from_ptr(printers_buffer.as_ptr() as *const c_char)
+                .to_string_lossy()
+                .into_owned()
+        };
+
+        Ok(printers_str
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_owned())
+            .collect())
+    }
+
     pub async fn open(name: String) -> Result<Self, Error> {
         INIT.call_once(|| {
             let handler = CallbackHandler::new();

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -332,6 +332,7 @@ EOF
   # Create `/usr/npi` and make `lp` group owner
   sudo mkdir -p /usr/npi
   sudo chown lp:lp /usr/npi
+  sudo chmod 770 /usr/npi
 
   # Add the current user to the lp group
   sudo usermod -aG lp "$(whoami)"

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -329,6 +329,10 @@ setup-label-printer() {
 SUBSYSTEM=="usb", ATTR{idVendor}=="1051", ATTR{idProduct}=="1000", MODE="0660", GROUP="lp"
 EOF
 
+  # Create `/usr/npi` and make `lp` group owner
+  sudo mkdir -p /usr/npi
+  sudo chown lp:lp /usr/npi
+
   # Add the current user to the lp group
   sudo usermod -aG lp "$(whoami)"
 }

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -364,6 +364,7 @@ setup-electionguard() {
 do-initial-build() {
   echo "🏗️ Initial Build"
   pnpm install
+  pnpm --dir apps/cacvote-mark/backend playwright install --with-deps chromium
   cargo build
   pnpm -r build:rust-addon
   pnpm --dir apps/cacvote-mark/frontend build

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -287,7 +287,9 @@ setup-kiosk-browser() {
 setup-label-printer() {
   echo "🖨️ Label Printer Driver"
 
-  local LIB_PATH="/usr/lib/libNPrint.so"
+  local LIB_PATH="/usr/lib/libNPrint.so.2.9"
+  local LIB_MAJOR_SYMLINK="/usr/lib/libNPrint.so.2"
+  local LIB_CURRENT_SYMLINK="/usr/lib/libNPrint.so"
   local ZIP_FILE
   local LIB_INSIDE_ZIP
 
@@ -313,12 +315,22 @@ setup-label-printer() {
 
     # Extract and install the library
     unzip -p "${ZIP_FILE}" "${LIB_INSIDE_ZIP}" | sudo tee "${LIB_PATH}" > /dev/null
+    sudo ln -sf "${LIB_PATH}" "${LIB_MAJOR_SYMLINK}"
+    sudo ln -sf "${LIB_MAJOR_SYMLINK}" "${LIB_CURRENT_SYMLINK}"
   fi
 
   (
     cd apps/cacvote-mark/nprint
     cargo build --release
   )
+
+  # Add a udev rule for the label printer so the `lp` group has read and write access
+  sudo tee /etc/udev/rules.d/99-label-printer.rules <<EOF
+SUBSYSTEM=="usb", ATTR{idVendor}=="1051", ATTR{idProduct}=="1000", MODE="0660", GROUP="lp"
+EOF
+
+  # Add the current user to the lp group
+  sudo usermod -aG lp "$(whoami)"
 }
 
 setup-electionguard() {

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -364,6 +364,7 @@ setup-electionguard() {
 do-initial-build() {
   echo "🏗️ Initial Build"
   pnpm install
+  pnpm playwright install
   cargo build
   pnpm -r build:rust-addon
   pnpm --dir apps/cacvote-mark/frontend build

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -364,7 +364,7 @@ setup-electionguard() {
 do-initial-build() {
   echo "🏗️ Initial Build"
   pnpm install
-  pnpm --dir apps/cacvote-mark/backend playwright install --with-deps chromium
+  (cd apps/cacvote-mark/backend && pnpm playwright install --with-deps chromium)
   cargo build
   pnpm -r build:rust-addon
   pnpm --dir apps/cacvote-mark/frontend build

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -364,7 +364,6 @@ setup-electionguard() {
 do-initial-build() {
   echo "🏗️ Initial Build"
   pnpm install
-  pnpx playwright install
   cargo build
   pnpm -r build:rust-addon
   pnpm --dir apps/cacvote-mark/frontend build

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -365,6 +365,8 @@ do-initial-build() {
   pnpm install
   cargo build
   pnpm -r build:rust-addon
+  pnpm --dir apps/cacvote-mark/frontend build
+  pnpm --dir apps/cacvote-jx-terminal/frontend build
 }
 
 setup-prereqs

--- a/script/cacvote-setup
+++ b/script/cacvote-setup
@@ -364,7 +364,7 @@ setup-electionguard() {
 do-initial-build() {
   echo "🏗️ Initial Build"
   pnpm install
-  pnpm playwright install
+  pnpx playwright install
   cargo build
   pnpm -r build:rust-addon
   pnpm --dir apps/cacvote-mark/frontend build


### PR DESCRIPTION
There are a few problems with the old setup:

1. We didn't have any way of granting permissions to the printer to the current user (fixed with udev config and `lp` group membership).
2. We didn't install the playwright chromium browser for rendering the label (fixed by triggering the install on setup).
3. We didn't install the shared object correctly so it would either fail the `nprint` build or fail to be loaded at runtime.
4. We didn't ever enumerate the label printers before trying to connect, but per the docs we need to do that or `libNPrint` cannot establish a connection at all.